### PR TITLE
Add CMake as an explicit dependency for Groovy

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -86,6 +86,7 @@ Groovy Galapagos (Oct 2012)
 - Boost 1.46
 - Lisp SBCL 1.0.x
 - Python 2.7
+- CMake 2.8.3
 
 Motivation
 ==========


### PR DESCRIPTION
Depending on 2.8.3 (with is available in all targeted platform) enable the use of CMake functions like cmake_parse_arguments.
