### PR TITLE
REP-3: Add numbers to Ubuntu version codenames

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -12,8 +12,8 @@ Abstract
 ========
 
 This REP defines target platforms for each ROS Distribution Release.
-We define platforms to include both operating system releases (Ubuntu
-Lucid) as well as major language releases (e.g. Python 2.6). The
+We define platforms to include both operating system releases (e.g. Ubuntu
+Lucid (10.04 LTS)) as well as major language releases (e.g. Python 2.6). The
 target platforms represent the set on which all core stacks are
 expected to work. Exceptions can be made for stacks that are
 intentionally platform-specific.
@@ -26,10 +26,10 @@ sent to ros-developers to enable discussion of this issue.
 
 Box Turtle (Feb 2010)
 ---------------------
-- Ubuntu Hardy
-- Ubuntu Intrepid
-- Ubuntu Jaunty
-- Ubuntu Karmic
+- Ubuntu Hardy (8.04 LTS)
+- Ubuntu Intrepid (8.10)
+- Ubuntu Jaunty (9.04)
+- Ubuntu Karmic (9.10)
 - C++03
 - Boost 1.37
 - Lisp SBCL 1.0.38
@@ -37,10 +37,10 @@ Box Turtle (Feb 2010)
 
 C Turtle (Aug 2010)
 -------------------
-- Ubuntu Jaunty
-- Ubuntu Karmic
-- Ubuntu Lucid
-- Ubuntu Maverick
+- Ubuntu Jaunty (9.04)
+- Ubuntu Karmic (9.10)
+- Ubuntu Lucid (10.04 LTS)
+- Ubuntu Maverick (10.10)
 - C++03
 - Boost 1.37
 - Lisp SBCL 1.0.38
@@ -48,9 +48,9 @@ C Turtle (Aug 2010)
 
 Diamondback (Feb 2011)
 ----------------------
-- Ubuntu Lucid
-- Ubuntu Maverick
-- Ubuntu Natty
+- Ubuntu Lucid (10.04 LTS)
+- Ubuntu Maverick (10.10)
+- Ubuntu Natty (11.04)
 - C++03
 - Boost 1.40
 - Lisp SBCL 1.0.38
@@ -58,10 +58,10 @@ Diamondback (Feb 2011)
 
 Electric Emys (Aug 2011)
 ------------------------
-- Ubuntu Lucid
-- Ubuntu Maverick
-- Ubuntu Natty
-- Ubuntu Oneiric
+- Ubuntu Lucid (10.04 LTS)
+- Ubuntu Maverick (10.10)
+- Ubuntu Natty (11.04)
+- Ubuntu Oneiric (11.10)
 - C++03
 - Boost 1.40
 - Lisp SBCL 1.0.x
@@ -69,9 +69,9 @@ Electric Emys (Aug 2011)
 
 Fuerte Turtle (Mar 2012)
 ------------------------
-- Ubuntu Lucid
-- Ubuntu Oneiric
-- Ubuntu Precise
+- Ubuntu Lucid (10.04 LTS)
+- Ubuntu Oneiric (11.10)
+- Ubuntu Precise (12.04 LTS)
 - C++03
 - Boost 1.40
 - Lisp SBCL 1.0.x
@@ -79,9 +79,9 @@ Fuerte Turtle (Mar 2012)
 
 Groovy Galapagos (Oct 2012)
 ---------------------------
-- Ubuntu Oneiric
-- Ubuntu Precise
-- Ubuntu Quantal
+- Ubuntu Oneiric (11.10)
+- Ubuntu Precise (12.04 LTS)
+- Ubuntu Quantal (12.10)
 - C++03
 - Boost 1.46
 - Lisp SBCL 1.0.x
@@ -90,9 +90,9 @@ Groovy Galapagos (Oct 2012)
 
 Hydro Medusa (Apr 2013)
 -----------------------
-- Ubuntu Precise
-- Ubuntu Quantal
-- Ubuntu Raring
+- Ubuntu Precise (12.04 LTS)
+- Ubuntu Quantal (12.10)
+- Ubuntu Raring (13.04)
 - C++03
 - Boost 1.48
 - Lisp SBCL 1.0.x
@@ -142,7 +142,7 @@ maintaining stability of the existing release.
 We generally expect to use the ROS Distribution release prior to an
 Ubuntu LTS release to transition to newer libraries and drop support
 for older platforms. Our past experience with Ubuntu releases is that
-the release prior to an LTS release (e.g. Karmic) incorporates major
+the release prior to an LTS release (e.g. Karmic (9.10)) incorporates major
 jumps in library versions; also, this release is generally very
 similar to the LTS release. Requiring that all stacks be compatible
 across a wide spread of Ubuntu releases can be very difficult,


### PR DESCRIPTION
Assuming I'm not the only one cross-checking each time.
