### PR TITLE
Withdrawing REP 9

### DIFF
--- a/rep-0009.rst
+++ b/rep-0009.rst
@@ -1,7 +1,7 @@
 REP: 9
 Title: ABI Compatibility
 Author: Josh Faust
-Status: Active
+Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst
 Created: 08-Oct-2010


### PR DESCRIPTION
This REP is not well enough scoped to be followed. We should not have it marked as active and have people expect ABI compatibility.

Fixes #55 
