### PR TITLE
Add recommendation to use RESULT-SPACE

### DIFF
--- a/rep-0128.rst
+++ b/rep-0128.rst
@@ -134,7 +134,13 @@ The term result space can be used for either a development space or an
 install space.
 In cases where either of those two specific terms would do, the
 generic term should be used instead.
+To visually distinguish the result space from spaces that have a direct 
+folder name correspondence (such as the folder ``install`` for the install 
+space) it is recommended to refer to the result space as ``RESULT-SPACE`` 
+in documention, for example:
+::
 
+    source RESULT-SPACE/setup.sh
 
 Overlays
 ========


### PR DESCRIPTION
This is a suggested resolution for the discussion in https://github.com/ros-infrastructure/rep/issues/78#issuecomment-46446157

Possible alternative `<result-space>` is less preferable IMO due to the special meaning of the `<` and `>` characters on the shell (consider people blindly copy&pasting such instructions to their shell).
