### PR TITLE
Adding geographical clarifications to REP-0103.

### DIFF
--- a/rep-0103.rst
+++ b/rep-0103.rst
@@ -169,12 +169,12 @@ Geographical Frames
 ===================
 
 Systems representing global geographical locations should do so using
-latitude and longitude, referencing the `WGS 84 ellipsoid`_, with
-altitude specified in meters above the ellipsoid.
+latitude and longitude in float64 decimal degrees, referencing the
+`WGS 84 ellipsoid`_, with altitude specified in meters above the ellipsoid.
 
-It may also be desirable to define a local cartesian frame,
+It may also be desirable to define a local Cartesian frame,
 especially as this allows a GNSS- or compass-equipped system to
-interoperate with software built around cartesian indoor systems.
+interoperate with software built around Cartesian indoor systems.
 
 .. _WGS 84 ellipsoid: http://en.wikipedia.org/wiki/World_Geodetic_System
 
@@ -182,7 +182,7 @@ interoperate with software built around cartesian indoor systems.
 Axis Orientation
 ----------------
 
-Representations of cartesian geographical locations should be made using
+Representations of Cartesian geographical locations should be made using
 the `east north up`_ (ENU) convention:
 
 * X east


### PR DESCRIPTION
This pull request adds some clarification to REP-0103 about how systems aware of their global location and orientation should represent that information in standard cartesian ROS messages.

As the manufacturer of many outdoor, GNSS-equipped ROS systems, @clearpathrobotics is strongly interested in having clarity around these issues, as it helps us deliver value and consistency to our users, helps our users understand how their systems are configured, and helps everyone achieve harmonious integration between different IMUs, GNSSes, and INSes, as well as higher level localization and planning systems.

I'd prefer to save this follow-on discussion for later, but the larger context here is to work toward an amendment or follow-on to REP-0105 which would clarify what the meanings of the `odom` and `map` frames are in a globally-aware system, and whether a new frame is required which represents an absolute reference.
