### PR TITLE
mark REP 143 final

### DIFF
--- a/rep-0143.rst
+++ b/rep-0143.rst
@@ -1,7 +1,7 @@
 REP: 143
 Title: ROS distribution files
 Author: Dirk Thomas <dthomas@osrfoundation.org>
-Status: Draft
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 01-Sep-2014


### PR DESCRIPTION
Since the original announcement on Nov 29th 2014 the received comments have been processed:

* https://github.com/ros-infrastructure/rosdistro/pull/45
* https://github.com/ros-infrastructure/rep/pull/87

Before rolling REP 143 out into the main rosdistro repo (which is required before we can roll out the new build farm) the REP should be marked final.

@esteve @tfoote @wjwwood Please approve.