### PR TITLE
add rosparam naming conventions [REP 146]

### DIFF
--- a/rep-0146.rst
+++ b/rep-0146.rst
@@ -10,21 +10,20 @@ Post-History:
 Abstract
 ========
 
-This REP aims to define the best practices for robot related parameter
-name space for making robot-agnostic packages.
+This REP aims to define best practices for robot-related ROS parameters
+for use in robot-agnostic packages.
 
 
 Motivation
 ==========
 
-As the number of ROS-supported robot increases, we will write
+As the number of ROS-supported robots increases, we will write
 robot-agnostic packages, but still they need robot-specific
-information as calibration parameters.
+information, such as calibration parameters.
 
-A `robot_description` parameter is widely shared naming convention
-among ROS community and this REP proposes such conventions for robot specific information on
-parameter, so application program can build their program on top of that.
-
+The `robot_description` parameter is an example of a widely shared naming convention
+among the ROS community. This REP proposes similar conventions for robot-specific information to be stored on the
+parameter server, helping applications that use these parameters to more easily run on a greater range of platforms.
 
 Specifications
 ==============
@@ -36,19 +35,18 @@ robot_description
 '''''''''''''''''
 
 `robot_description` stores robot kinematics / geometry information using
-URDF format.
+the URDF format.
 
 
 robot_type
 ''''''''''
-
-The `robot_type` should capture the name of the class of robot in a way that a user would understand the scope of the robot. If it's a commercial product it is recommended to use the production model name. ` For example 'pr2' in PR2 robot case [1], 'pepper' in Pepper robot case and 'fetch' in Fetch robot cases.
+The `robot_type` should capture the name of the class of robot in a way that a user would understand the scope of the robot. If it's a commercial product it is recommended to use the production model name. For example 'pr2' in PR2 robot case [1], 'pepper' in Pepper robot case and 'fetch' in Fetch robot cases.
 
 
 robot_name
 ''''''''''
 
-`robot_name` stores robot name. It should be set to make sure that this robot instance is unique on the system in much that computers are recommended to have unique hostnames. For the case of PR2 robot, the default robot name is 'robot' [1], but other individuals have named 'james', 'gutsy' etc...
+`robot_name` stores the robot's unique name. It should be set to make sure that this robot instance is unique on the system, in same way that computers are recommended to have unique hostnames. For the case of PR2 robot, the default robot name is 'robot' [1], but other individuals have named 'james', 'gutsy' etc...
 
 
 Examples

--- a/rep-0146.rst
+++ b/rep-0146.rst
@@ -1,0 +1,62 @@
+REP: 146
+Title: ROS Robot Parameter Naming Convention
+Author: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
+Status: Draft
+Type: Informational
+Content-Type: text/x-rst
+Created: 31-Jly-2015
+Post-History:
+
+Abstract
+========
+
+This REP aims to define the best practices for robot related parameter
+name space for making robot-agnostic packages.
+
+
+Motivation
+==========
+
+As the number of ROS-supported robot increases, we will write
+robot-agnostic packages, but still they need robot-specific
+information as calibration parameters.
+
+A `robot_description` parameter is widely shared naming convention
+among ROS community and this REP proposes such conventions for robot specific information on
+parameter, so application program can build their program on top of that.
+
+
+Specifications
+==============
+
+Parameters
+----------
+
+robot_description
+'''''''''''''''''
+
+`robot_description` stores robot kinematics / geometry information using
+URDF format.
+
+
+robot/type
+''''''''''
+
+`robot/type` stores robot type, for example 'pr2' in PR2 robot case [1]
+
+
+robot/name
+''''''''''
+
+`robot/name` stores robot name, default pr2 name is 'robot' [1]
+
+References
+==========
+
+.. [1] PR2 robot.yaml
+   (https://github.com/pr2-debs/pr2-core/blob/master/root/etc/ros/robot.yaml)
+
+Copyright
+=========
+
+This document has been placed in the public domain.

--- a/rep-0146.rst
+++ b/rep-0146.rst
@@ -50,6 +50,24 @@ robot/name
 
 `robot/name` stores robot name, default pr2 name is 'robot' [1]
 
+robot/info
+''''''''''
+
+`robot/info` stores any other characteristics of the robot, including type, serial number, owner name / email address, timezone, language it uses ...
+
+Examples
+========
+
+
+Example behaviors::
+
+    $ rosparam get robot/name
+    olive
+    $ rosparam get robot/type
+    pepper
+    $ rosparam get robot/info
+    {serial number: 00000000, owner name : Kei Okada, language: Japanese,....}
+
 References
 ==========
 

--- a/rep-0146.rst
+++ b/rep-0146.rst
@@ -42,18 +42,14 @@ URDF format.
 robot_type
 ''''''''''
 
-`robot_type` stores robot type in lower cases, for example 'pr2' in PR2 robot case [1], 'pepper' in Pepper robot case and 'fetch' in Fetch robot cases. This could be regarded as manufacturer's model name.
+The `robot_type` should capture the name of the class of robot in a way that a user would understand the scope of the robot. If it's a commercial product it is recommended to use the production model name. ` For example 'pr2' in PR2 robot case [1], 'pepper' in Pepper robot case and 'fetch' in Fetch robot cases.
 
 
 robot_name
 ''''''''''
 
-`robot_name` stores robot name, default pr2 name is 'robot' [1], which is given individual name to the robot. So robot name of 'pr2' robot type could be 'james', 'gutsy' etc...
+`robot_name` stores robot name. It should be set to make sure that this robot instance is unique on the system in much that computers are recommended to have unique hostnames. For the case of PR2 robot, the default robot name is 'robot' [1], but other individuals have named 'james', 'gutsy' etc...
 
-robot/info
-''''''''''
-
-`robot_info` stores any other characteristics of the robot in YAML dict type, including type, serial number, owner name / email address, timezone, language it uses ...
 
 Examples
 ========
@@ -65,8 +61,6 @@ Example behaviors::
     olive
     $ rosparam get robot_type
     pepper
-    $ rosparam get robot_info
-    {serial number: 00000000, owner name : Kei Okada, language: Japanese,....}
 
 References
 ==========

--- a/rep-0146.rst
+++ b/rep-0146.rst
@@ -39,21 +39,21 @@ robot_description
 URDF format.
 
 
-robot/type
+robot_type
 ''''''''''
 
-`robot/type` stores robot type, for example 'pr2' in PR2 robot case [1]
+`robot_type` stores robot type in lower cases, for example 'pr2' in PR2 robot case [1], 'pepper' in Pepper robot case and 'fetch' in Fetch robot cases. This could be regarded as manufacturer's model name.
 
 
-robot/name
+robot_name
 ''''''''''
 
-`robot/name` stores robot name, default pr2 name is 'robot' [1]
+`robot_name` stores robot name, default pr2 name is 'robot' [1], which is given individual name to the robot. So robot name of 'pr2' robot type could be 'james', 'gutsy' etc...
 
 robot/info
 ''''''''''
 
-`robot/info` stores any other characteristics of the robot, including type, serial number, owner name / email address, timezone, language it uses ...
+`robot_info` stores any other characteristics of the robot in YAML dict type, including type, serial number, owner name / email address, timezone, language it uses ...
 
 Examples
 ========
@@ -61,11 +61,11 @@ Examples
 
 Example behaviors::
 
-    $ rosparam get robot/name
+    $ rosparam get robot_name
     olive
-    $ rosparam get robot/type
+    $ rosparam get robot_type
     pepper
-    $ rosparam get robot/info
+    $ rosparam get robot_info
     {serial number: 00000000, owner name : Kei Okada, language: Japanese,....}
 
 References


### PR DESCRIPTION
A `robot_description` parameter is widly shared naming convention
among ROS cummnity and this REP proposes such conventions for robot specific information on
parameter, so application program can build their program on top of that.
