### PR TITLE
Update to REP-0003 for ROS Kinetic Kame

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -5,7 +5,7 @@ Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 21-Sep-2010
-Post-History: 21-Sep-2010, 17-Jan-2011, 13-Jan-2015
+Post-History: 21-Sep-2010, 17-Jan-2011, 13-Jan-2015, 21-Sep-2015
 
 
 Abstract
@@ -115,7 +115,6 @@ Hydro Medusa (Aug 2013)
 
 - For rosbuild based packages can still be built from source.
 
-
 Indigo Igloo (May 2014)
 -----------------------
 - Ubuntu Saucy (13.10)
@@ -180,6 +179,52 @@ Buildsystem support:
 
   - build from source
 
+Kinetic Kame (May 2016 - May 2021)
+----------------------------------
+Required Support for:
+
+- Ubuntu Wily (15.10)
+- Ubuntu Xenial (16.04)
+
+Minimum Requirements:
+
+- C++11
+
+  - GCC 4.9 on Linux, as it's the version that Debian Jessie ships with
+
+- Python 2.7
+
+  - Python 3.4 not required, but testing against it is recommended
+
+- Lisp SBCL 1.2.4
+- CMake 3.0.2
+
+  - Debian Jessie ships with CMake 3.0.2
+
+- Boost 1.55
+
+  - Debian Jessie ships with Boost 1.55
+
+Exact or Series Requirements:
+
+- Ogre3D 1.9.x
+- Gazebo 7
+- PCL 1.7.x
+- OpenCV 3.1.x
+
+Buildsystem support:
+
+- catkin:
+
+  - build from source
+  - release for binary packaging
+  - wiki documentation
+  - continuous integration
+
+- rosbuild:
+
+  - build from source
+
 Motivation
 ==========
 
@@ -205,7 +250,7 @@ While we mainly develop with gcc, no use of compiler-specific features is allowe
 without proper use of macros to allow use on other platforms.
 
 Use of C++11/C++14 features and filesystem/networking/etc... TS's (Technical Specifications) is allowed if they are checked for at configure time and equivalent functionality can be provided with the extra compiler features.
-We will continue using only C++03 features to preserve backwards compatibility, but code must also compile with C++11 compilers, i.e. when ``-std=c++11`` is used.
+Support for C++11 is now a compiler requirement, but the API of the packages included in desktop-full will not use any C++11-specific feature. External packages are encouraged to follow this guideline.
 
 For a given release we allow use of Boost libraries that match the version provided in our
 low-water-mark Ubuntu version.


### PR DESCRIPTION
I've updated the requirements for Kinetic Kame. @scpeters has expressed interest in ROS having support for C++11 for better compatibility with newer versions of SDFormat. I don't know if the version of Gazebo should be 5 or 6, and the list of C++11 features will be expanded as we see if they can benefit our users (e.g. lambdas for subscriptions, `std::shared_ptr` instead of boost's)