### PR TITLE
[REP 142] Remove superfluous dependencies from desktop (already in viz)

### DIFF
--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -145,9 +145,7 @@ Both of these variants contain tutorials for the stacks they provide.
   - desktop:
       extends: [robot, viz]
       packages: [common_tutorials, geometry_tutorials, ros_tutorials,
-                 roslint, rqt_common_plugins,
-                 rqt_robot_plugins, urdf_tutorials,
-                 visualization_tutorials]
+                 roslint, urdf_tutorials, visualization_tutorials]
   - desktop_full:
       extends: [desktop, perception, simulators]
 


### PR DESCRIPTION
The ros-desktop metapackage now only contains tutorials and roslint (which should probably go somewhere like core or base). So in principal we could rename this to ros-tutorials and ros-desktop-full to ros-desktop, but that's probably to late in the game...