### PR TITLE
Add Qt 5 requirement to ROS Kinetic

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -211,6 +211,8 @@ Exact or Series Requirements:
 - Gazebo 7
 - PCL 1.7.x
 - OpenCV 3.1.x
+- Qt 5.3.x
+- PyQt5
 
 Buildsystem support:
 


### PR DESCRIPTION
Because support for Qt4 has ended, we propose migrating rqt and rviz to Qt5 in Kinetic.

This will affect maintainers of rviz and rqt plugins, who will need to update their code to Qt5.

We do not expect the Qt4 -> Qt5 migration to require significant code changes.

See the Qt Wiki for a migration guide: https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5
For PyQt4/PyQt5, see: http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html

Note that Kinetic will also support Gazebo 7, which still uses Qt4. (Qt5 migration is targeted for Gazebo 8) We have started experimenting with Qt5 migration in rqt and rviz and have confirmed the following:

* Qt4 and Qt5 can be installed on the same machine without package conflicts
* Gazebo 7 (which is linked against Qt4) can run side-by-side with Rviz linked against Qt5
* A `rviz` plugin built with Qt5 and a Gazebo 7 GUI plugin built with Qt4 can be built from source on the same machine

One corner case is any program which is both a Gazebo plugin and an Rviz plugin, which would need to depend on both Qt4 and Qt5. We aren't aware of any such plugin and have not experimented with writing one, but we suspect such a setup would be impossible because compiling code with Qt4 and Qt5 simultaneously is impossible.

You can check on the current status of Qt4/Qt5 migration for rviz, rqt and related rqt packages on GitHub:

* https://github.com/ros-visualization/python_qt_binding/compare/qt5
* https://github.com/ros-visualization/qt_gui_core/compare/qt5
* https://github.com/ros-visualization/rqt/compare/qt5
* https://github.com/ros-visualization/rqt_common_plugins/compare/qt5
* https://github.com/ros-visualization/rviz/compare/wjwwood-qt5

We have estimated the remaining work on rviz and rqt to take 2-3 weeks.

The current goal for Rviz is to maintain compatibility with Qt4 when built from source, but this may change in the next few weeks if more technical challenges with Python bindings prevent it from happening.

Regarding PySide support:

While PyQt has support for Qt5 for quite some time PySide is only in the early steps to support Qt5. While this is unfortunate PySide support was already broken in Indigo and Jade when building on Trusty (due to a bug in the code generator in the upstream Ubuntu package `shiboken`). We will investigate using PySide with Qt5 in the coming weeks, but if it is not yet working we will still move forward and add support for it once upstream development has caught up.