### PR TITLE
updating 142 to add gennodejs as kinetic ros_core pkg

### DIFF
--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -60,14 +60,15 @@ ROS Core
 The `ros_core` metapackage composes the core communication protocols.
 It may not contain any GUI dependencies.
 In ROS Jade `ros_core` is extended to include `geneus`.
+In ROS Kinetic `ros_core` is extended to include `genjs`.
 
 ::
 
  - ros_core:
       extends: [ros, ros_comm]
       packages: [catkin, cmake_modules, common_msgs, console_bridge,
-                 gencpp, geneus(Jade and newer), genlisp, genmsg, genpy, message_generation,
-                 message_runtime,
+                 gencpp, geneus(Jade and newer), genjs(Kinetic and newer),
+                 genlisp, genmsg, genpy, message_generation, message_runtime,
                  rosbag_migration_rule, rosconsole_bridge,
                  roscpp_core, rosgraph_msgs, roslisp, rospack,
                  std_msgs, std_srvs]

--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -60,14 +60,14 @@ ROS Core
 The `ros_core` metapackage composes the core communication protocols.
 It may not contain any GUI dependencies.
 In ROS Jade `ros_core` is extended to include `geneus`.
-In ROS Kinetic `ros_core` is extended to include `genjs`.
+In ROS Kinetic `ros_core` is extended to include `gennodejs`.
 
 ::
 
  - ros_core:
       extends: [ros, ros_comm]
       packages: [catkin, cmake_modules, common_msgs, console_bridge,
-                 gencpp, geneus(Jade and newer), genjs(Kinetic and newer),
+                 gencpp, geneus(Jade and newer), gennodejs(Kinetic and newer),
                  genlisp, genmsg, genpy, message_generation, message_runtime,
                  rosbag_migration_rule, rosconsole_bridge,
                  roscpp_core, rosgraph_msgs, roslisp, rospack,


### PR DESCRIPTION
This adds `genjs` as a core ROS package for Kinetic:
https://github.com/RethinkRobotics-opensource/genjs

This will be used with `rosjs` Javascript ROS client library:
https://github.com/RethinkRobotics-opensource/rosjs
