### PR TITLE
Remove copy/pasta 'for' in Hydro & Indigo platform descriptions

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -113,7 +113,7 @@ Hydro Medusa (Aug 2013)
   - documenting
   - continuous integration testing
 
-- For rosbuild based packages can still be built from source.
+- Rosbuild based packages can still be built from source.
 
 Indigo Igloo (May 2014)
 -----------------------
@@ -134,7 +134,7 @@ Indigo Igloo (May 2014)
   - documenting
   - continuous integration testing
 
-- For rosbuild based packages can still be built from source.
+- Rosbuild based packages can still be built from source.
 
 Jade Turtle (May 2015 - May 2017)
 ---------------------------------


### PR DESCRIPTION
As per subject.

Probably copied from the *For both catkin and rosbuild packages [..]* bullet point above it.
