### PR TITLE
Add references to Debian Jessie and Fedora 23 24

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -186,6 +186,12 @@ Required Support for:
 - Ubuntu Wily (15.10)
 - Ubuntu Xenial (16.04)
 
+Recommended Support for: 
+
+- Debian Jessie
+- Fedora 23
+- Fedora 24
+
 Minimum Requirements:
 
 - C++11


### PR DESCRIPTION
These are the platforms for which bloom does a best effort to generate targets. https://github.com/ros/rosdistro/blob/master/kinetic/distribution.yaml#L5-L13

Follow up to https://github.com/ros/rosdistro/pull/12464#issuecomment-254027959
