### PR TITLE
Add optional package name exemptions.

### DIFF
--- a/rep-0127.rst
+++ b/rep-0127.rst
@@ -5,7 +5,7 @@ Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 12-Sep-2012
-Post-History: 22-Sep-2012
+Post-History: 22-Sep-2012, 16-May-2017
 
 Outline
 =======
@@ -239,6 +239,17 @@ The package name must start with a letter and contain only lowercase
 alphabetic, numeric or underscore characters [1]_.  The package name
 should be unique within the ROS community.  It may differ from the
 folder name into which it is checked out, but that is *not* recommended.
+
+The following recommended exemptions apply, which are optional for
+implementations:
+
+- Dashes may be permitted in package names. This is to support
+  maintaining a consistent dependency name when transitioning back
+  and forth between a system dependency and in-workspace package,
+  since many rosdep keys contain dashes (inherited from the
+  Debian/Ubuntu name).
+- In support of some legacy packages, capital letters may also be
+  accepted in the package name, with a validation warning.
 
 
 <version>
@@ -492,6 +503,15 @@ package and message generation tasks.
 
 This empty tag indicates that your package contains no
 architecture-specific files.
+
+<build_type>
+''''''''''''
+
+This tag indicates the package's build type. If unspecified, the
+default is ``catkin``. Typical value is ``cmake`` to denote a plain
+CMake package, but any string is allowed.
+
+The ``<build_type>`` tag may only be specified once.
 
 <deprecated>
 ''''''''''''

--- a/rep-0140.rst
+++ b/rep-0140.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 26-Jun-2013
-Post-History: 12-Mar-2014
+Post-History: 12-Mar-2014, 16-May-2017
 
 Outline
 =======
@@ -282,6 +282,17 @@ The package name must start with a letter and contain only lowercase
 alphabetic, numeric or underscore characters [2]_.  The package name
 should be unique within the ROS community.  It may differ from the
 folder name into which it is checked out, but that is *not* recommended.
+
+The following recommended exemptions apply, which are optional for
+implementations:
+
+- Dashes may be permitted in package names. This is to support
+  maintaining a consistent dependency name when transitioning back
+  and forth between a system dependency and in-workspace package,
+  since many rosdep keys contain dashes (inherited from the
+  Debian/Ubuntu name).
+- In support of some legacy packages, capital letters may also be
+  accepted in the package name, with a validation warning.
 
 
 <version>


### PR DESCRIPTION
Updating REP 127 with the implementation changes proposed in https://github.com/ros-infrastructure/catkin_pkg/pull/162.

Recognizing that the standard was already released, these are structured as an optional add-on rather than a new implementation requirement.