### PR TITLE
Add '.html' extension to rep_url template var to make header links work

### DIFF
--- a/docutils_transforms_reps.py
+++ b/docutils_transforms_reps.py
@@ -28,7 +28,7 @@ class Headers(Transform):
 
     default_priority = 360
 
-    rep_url = 'rep-%04d'
+    rep_url = 'rep-%04d.html'
     rep_git_url = \
         'https://github.com/ros-infrastructure/rep/blob/master/rep-%04d.rst'
     rcs_keyword_substitutions = (


### PR DESCRIPTION
As per subject.

Links to REPs in REP headers didn't include `.html`, making links (except those to `.rst` source files) `404`.
