### PR TITLE
Remove magic nr in content-type url generation.

### DIFF
--- a/docutils_transforms_reps.py
+++ b/docutils_transforms_reps.py
@@ -28,6 +28,7 @@ class Headers(Transform):
 
     default_priority = 360
 
+    rep_rst_nr = 12
     rep_url = 'rep-%04d'
     rep_git_url = \
         'https://github.com/ros-infrastructure/rep/blob/master/rep-%04d.rst'
@@ -127,7 +128,8 @@ class Headers(Transform):
                     para[:] = [nodes.reference('', date, refuri=repo_url)]
             elif name == 'content-type':
                 rep_type = para.astext()
-                uri = self.document.settings.rep_base_url + self.rep_url % 12
+                uri = (self.document.settings.rep_base_url + self.rep_url
+                       % self.rep_rst_nr)
                 para[:] = [nodes.reference('', rep_type, refuri=uri)]
             elif name == 'version' and len(body):
                 utils.clean_rcs_keywords(para, self.rcs_keyword_substitutions)


### PR DESCRIPTION
As per subject.

Seemed strange to have that `12` there, as other places in this class do use templates / constants for this sort of thing.
