### PR TITLE
add more operators to conditions

### DIFF
--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -606,7 +606,7 @@ Attributes
 
   * parenthesis (which must be balanced)
   * logical operators `and` and `or`
-  * comparison operators `==` and `!=`
+  * comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
   * variable names which start with a `$` sign and are followed by
     alphanumerics and underscores
   * literals which can only contain alphanumerics, undercsores and dashes
@@ -619,6 +619,8 @@ Attributes
   * All literals are also treated as strings.
   * The resulting expression is evaluated as a Python interpreter would
     evaluate it.
+    Please not that the comparison operators only do a *string* comparison and
+    don't attempt to interpret the string as a numerical value.
 
  Tools may populate the values for the variables starting with a `$` sign in
  different ways, but typically they are evaluated as environment variables.


### PR DESCRIPTION
Based on the feedback in #138. While we might not want to recommend using these operators for comparing the ROS distro name (since they will "wrap" in the future) we will provide the operators. So the user can choose if / what they want to use it for.