### PR TITLE
add draft for REP 151 - Python 3 support

### DIFF
--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -1,0 +1,223 @@
+REP: 151
+Title: Python 3 Support
+Author: Dirk Thomas
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 23-Dec-2017
+
+Outline
+=======
+
+#. Abstract_
+#. Motivation_
+#. Rationale_
+#. Proposal_
+#. Requirements_
+#. References_
+#. Copyright_
+
+Abstract
+========
+
+This REP describes the path for switching from Python 2 to Python 3 in ROS 1.
+
+Motivation
+==========
+
+As described in the Python release schedule [1]_ Python 2.7 will only receive
+bugfix releases until 2020.
+As a consequence Ubuntu is trying to demote Python 2.7 into the `universe`
+repository for 18.04 since they don't want to guarantee support for 5 years.
+While it is unlikely that Python 2.7 will be removed from the archives entirely
+it should not be relied on past its EOL date.
+Therefore ROS 1 needs to begin moving to Python 3 in order to make the
+transition as smooth as possible.
+
+Rationale
+=========
+
+The goal for a future ROS 1 distribution to support Python 3 should be achieved
+no later than for ROS O-turtle (May 2020).
+Since O-turtle is a LTS release it is strongly desired to already support
+Python 3 in the non-LTS release N-turtle to allow enough "soak" time.
+
+In general a single Python version must be used since different versions can't
+be mixed within a single ROS distribution.
+E.g. a package `A` using Python 3 can't use the Python modules from package `B`
+if that was built with/for Python 2.
+
+In order to support Python 3 it is mandatory that the testing infrastructure
+(namely `devel` and `PR` jobs) can run the build and tests with Python 3.
+Since each of these jobs require Debian packages of the dependencies to be
+present being able to test for a specific Python version requires Debian
+packages for this Python version to be present.
+The alternative of building all dependencies from-source in these jobs doesn't
+scale and is therefore not feasible since the time necessary for a single build
+gets increasingly high the further up in the stack the package is.
+
+Updating all ROS packages which contain Python code to support Python 2
+as well as 3 is a significant effort.
+Therefore it is expected that this will take a while and will require the ROS
+community to share the necessary workload.
+
+Proposals
+=========
+
+Neither of the proposals specifies a specific minimum minor version for Python
+3 support but focuses on the general effort to transition to Python 3.
+The minimum version is being defined in REP 3 [2]_ together with all other
+versions.
+
+A) Transition over multiple releases with dual Python version support inbetween
+-------------------------------------------------------------------------------
+
+The goals of this proposal are to provide early feedback for Python 3 related
+problems by providing parallel testing capabilities.
+The following timeline describes a transition over multiple ROS releases:
+
+ * ROS O-turtle (May 2020, LTS):
+
+   * The only Debian packages provided are using Python 3.
+   * From-source builds are using Python 3 by default.
+   * All ROS packages should support Python 3.
+   * Python 2 support is not required anymore.
+
+ * ROS N-turtle (May 2019):
+
+   * The set of recommended Debian packages is using Python 3.
+   * There is an alternative set of Debian packages which is using Python 2,
+     this can be used in case some packages don't support Python 3 yet.
+     These two sets of Debian packages should be side-by-side installable in
+     order to ease testing.
+   * From-source builds are using Python 3 by default, optionally choosing
+     Python 2 should be possible for all packages.
+   * All ROS packages should support Python 2 as well as Python 3.
+
+ * ROS Melodic (May 2018, LTS):
+
+   * The set of recommended Debian packages is using Python 2.
+   * There is an alternative set of Debian packages which is using Python 3,
+     this can be used by the CI infrastructure as well as users choosing to use
+     Python 3.
+   * From-source builds are using Python 2 by default, optionally choosing
+     Python 3 should be possible.
+   * All ROS packages should support Python 2 while support for Python 3 is
+     recommended (as it has been for the past ROS distributions).
+
+Requirements
+''''''''''''
+
+To support the proposal `A)` a few capabilities have to be developed:
+
+ * `catkin` / `catkin_tools` need to support choosing the Python version.
+
+ * `rosdep`: choose between Python 2 and Python 3 dependencies.
+   Multiple different options can be considered for this:
+
+   * Beside the `python.yaml` file create a `python3.yaml` file and let
+     `rosdep` choose between them.
+   * Use different installers for Python 2 and Python 3 packages, e.g. `xenial`
+     and `xenial_python3`, and let `rosdep` choose between them.
+   * Create explicit rosdep keys with a `python2` and `python3` prefix and use
+     them in the package manifest files with conditional dependencies as
+     specified in REP 149 [3]_.
+
+ * `bloom` needs to generate releases for both Python versions in parallel.
+   The user should only need to release each package once.
+
+ * `ros_buildfarm` needs to provide jobs for both Python versions in parallel.
+
+ * Across all ROS packages which contain Python code it needs to be ensured
+   that they support both major Python versions.
+   In the majority of the cases this can be easily achieved, some examples how
+   to convert Python 2-only code to work for both major versions can be found
+   in the ROS wiki [4]_.
+
+B) Transition from one release to the next
+------------------------------------------
+
+This proposal minimizes the effort necessary on the infrastructure and tooling
+side.
+Instead of supporting both Python versions in parallel the only supported
+Python version changes from one release to the next:
+
+ * ROS O-turtle (May 2020, LTS):
+
+   * The Debian packages as well as the infrastructure and tools only support
+     Python 3.
+
+ * ROS N-turtle (May 2019):
+
+   * The Debian packages as well as the infrastructure and tools only support
+     Python 3.
+   * To maximize the testing time the buildfarm should be provided as early as
+     possible (around November 2018 once the first Ubuntu 19.04 packages are
+     available).
+   * The downside of this is that N-turtle will target the same Ubuntu LTS
+     18.04 which makes it more difficult to choose the "right" `rosdep`
+     mapping.
+     The effort is not higher than for proposal `A)` though.
+     An alternative would be to keep using Python 2 in N-turtle and only switch
+     to Python 3 in O-turtle but that would imply a drastic change in an LTS
+     release which doesn't seem to be a good idea.
+
+ * ROS Melodic (May 2018, LTS):
+
+   * The Debian packages as well as the infrastructure and tools only support
+     Python 2.
+   * It should be made possible to do a from-source build with Python 3 for
+     early testing.
+   * It is encouraged to make the code base work with both Python version in
+     order to ease the upcoming transition.
+
+Requirements
+''''''''''''
+
+To support the proposal `B)` less effort is necessary compared to proposal
+`A)`:
+
+ * `rosdep`: choose between Python 2 and Python 3 dependencies.
+
+ * `bloom` needs to generate releases for both Python versions in parallel.
+   The user should only need to release each package once.
+
+ * `ros_buildfarm` needs to provide jobs for both Python versions in parallel.
+
+ * ROS packages don't have to support both Python versions in parallel but they
+   all have to switch to Python 3 for the same release.
+   While the effort is slightly lower than to support both Python versions
+   simultaneously the transition window is rather short.
+
+Conclusion
+==========
+
+While proposal `A)` provides a smoother transition it requires a significantly
+higher development effort.
+Due to the sparse resource available proposal `B)` is being chosen.
+
+References
+==========
+
+.. [1] PEP 373 Python 2.7 Release Schedule
+   (https://www.python.org/dev/peps/pep-0373/)
+.. [2] REP-0003 Target Platforms
+   (http://ros.org/reps/rep-0003)
+.. [3] REP-0149 Package Manifest Format Three Specification
+   (http://ros.org/reps/rep-0149)
+.. [4] ROS Wiki - Python 2 and 3 compatible code
+   (http://wiki.ros.org/python_2_and_3_compatible_code)
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -291,6 +291,11 @@ While proposal `A)` provides a smoother transition it requires a significantly
 higher development effort.
 Proposal `B)` requires the least tooling effort, but will be the roughest on the
 community, offering little in the way of a migration plan.
+Proposal `C)` also provides a smooth transition, but also requires significantly
+higher development effort.
+
+Since there are limited resources available to fix the tooling, Proposal B) will
+be chosen and implemented.
 
 References
 ==========

--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -69,8 +69,8 @@ Neither of the proposals specifies a specific minimum minor version for Python
 The minimum version is being defined in REP 3 [2]_ together with all other
 versions.
 
-A) Transition over multiple releases with dual Python version support inbetween
--------------------------------------------------------------------------------
+A) Transition over multiple releases (separate debs for other Python)
+---------------------------------------------------------------------
 
 The goals of this proposal are to provide early feedback for Python 3 related
 problems by providing parallel testing capabilities.
@@ -189,12 +189,108 @@ To support the proposal `B)` less effort is necessary compared to proposal
    While the effort is slightly lower than to support both Python versions
    simultaneously the transition window is rather short.
 
+C) Transition over multiple releases (single set of bilingual debs)
+-------------------------------------------------------------------
+
+Similar goals and timeline to proposal `A)`, but with only a single set of
+installable debs, significantly lowering the complexity barrier for users and
+package deveopers/maintainers.
+
+The concept is that each installed package which supplies Python modules will be able
+to migrate to dual Python 2/3 support during ROS Melodic, such that leaf Python packages
+are able to opt into Python 3 any time during M or N, whenever their dependencies are
+ready to go.
+
+This proposal offers flexibility to users, with the primary costs being the risk of
+user confusion or side effects around the "alternative python" shim, and the cost
+of dual-depending on all Python dependencies, which may frustrate users with limited
+disk who would prefer not to have both `python-numpy` and `python3-numpy` installed
+unncessarily.
+
+The following timeline describes a transition over multiple ROS releases:
+
+ * ROS O-turtle (May 2020, LTS):
+
+   * Debian packages using catkin_setup_python install to
+     `lib/python3/dist-packages/`.
+   * From-source builds use Python 3 by default.
+   * All ROS packages should support Python 3.
+
+ * ROS N-turtle (May 2019):
+
+   * Debian packages using catkin_setup_python install to both
+     `lib/python3/dist-packages/` and `lib/python2.7/dist-packages/`
+   * Default behaviour of `catkin_install_python` (with an ambiguous
+     `usr/bin/env python` shebang) is to use Python 3. Users may choose
+     explicitly a `python2` or `python3` shebang, as desired.
+   * From-source builds are using Python 3 by default; users may choose
+     instead Python 2 or to use the dual-build behaviour.
+
+ * ROS Melodic (May 2018, LTS):
+ 
+   * Debian packages using catkin_setup_python install to both
+     `lib/python3/dist-packages/` and `lib/python2.7/dist-packages/`
+   * Default behaviour of `catkin_install_python` (with an ambiguous
+     `usr/bin/env python` shebang) is to use Python 2. Users may choose
+     explicitly a `python2` or `python3` shebang, as desired.
+   * From-source builds are using Python 2 by default; users may choose
+     instead Python 3 or to use the dual-build behaviour.
+
+Requirements
+''''''''''''
+
+To support the proposal `C)` a few capabilities must be developed in catkin:
+
+ * It will need to be updated with bilingual awareness around the
+   `catkin_install_python` and `catkin_python_setup` functions.
+   
+ * The existing `PYTHON_EXECUTABLE`, `PYTHON_LIBRARY`, and `PYTHON_INCLUDE_DIR`
+   variables which may be used today to select the preferred Python will need to
+   be supplemented by a separate `PYTHON_ALT_*` vars which control which Python is
+   used for the second `setup.py` invocation. If the `PYTHON_ALT_*` vars are unset,
+   catkin will build only for the default Python (this would be default behaviour
+   in a source workspace, in order to not break Arch and other from-source systems
+   where `/usr/bin/python` is already Python 3).
+   
+ * Similarly, Python nosetests will run twice if the `PYTHON_ALT_*` vars are set.
+   Perhaps a CMake function could be used to disable this behaviour, especially
+   for packages which migrate to Python 3 and don't want to receive test failures for
+   Python 2 issues. For example, `catkin_python_policy(ONLY_3)` or similar.
+ 
+ * In order to do the right thing with conventional `usr/bin/env python3` shebangs,
+   ROS Melodic will need to ship a small wrapper shim which mutates the `PYTHONPATH`
+   variable. This shim would live at `/opt/ros/melodic/bin/python3` and look like
+    ```
+    #!/bin/sh
+    PYTHONPATH=$(echo $PYTHONPATH | sed "s/lib\/python2\.7/lib\/python3/")
+    /usr/bin/python3 $*
+    ```
+   Similarly, ROS N would have to do the reverse operation in a `python2` shim. No
+   shim would be required for ROS O and beyond. This shim could be part of the
+   `catkin` package itself, or potentially live separately.
+
+And in other tools:
+
+ * `rosdep`: choose between Python 2 and Python 3 dependencies.
+ 
+ * `bloom`: For the transitional releases (N and M), the default bloom behaviour will
+   be to depend on both the Python 2 and Python 3 versions of all Python dependencies.
+
+ * `ros_buildfarm` should set the new `PYTHON_ALT_*` vars according to the release
+   plan given above.
+   
+ * Packages which generate compiled Python extensions will require bespoke CMake
+   logic to ensure that these extensions are correctly built and installed twice.
+   Upon examining the individual cases, it's possible that the `catkin` package may
+   be able to provide some tooling to streamline this.
+
 Conclusion
 ==========
 
 While proposal `A)` provides a smoother transition it requires a significantly
 higher development effort.
-Due to the sparse resource available proposal `B)` is being chosen.
+Proposal `B)` requires the least tooling effort, but will be the roughest on the
+community, offering little in the way of a migration plan.
 
 References
 ==========

--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -12,8 +12,9 @@ Outline
 #. Abstract_
 #. Motivation_
 #. Rationale_
-#. Proposal_
-#. Requirements_
+#. Proposals_
+#. Rosdep_
+#. Conclusion_
 #. References_
 #. Copyright_
 
@@ -112,16 +113,8 @@ To support the proposal `A)` a few capabilities have to be developed:
 
  * `catkin` / `catkin_tools` need to support choosing the Python version.
 
- * `rosdep`: choose between Python 2 and Python 3 dependencies.
-   Multiple different options can be considered for this:
-
-   * Beside the `python.yaml` file create a `python3.yaml` file and let
-     `rosdep` choose between them.
-   * Use different installers for Python 2 and Python 3 packages, e.g. `xenial`
-     and `xenial_python3`, and let `rosdep` choose between them.
-   * Create explicit rosdep keys with a `python2` and `python3` prefix and use
-     them in the package manifest files with conditional dependencies as
-     specified in REP 149 [3]_.
+ * `rosdep`: choose between Python 2 and Python 3 dependencies; see the Rosdep_
+    section for more information.
 
  * `bloom` needs to generate releases for both Python versions in parallel.
    The user should only need to release each package once.
@@ -177,7 +170,8 @@ Requirements
 To support the proposal `B)` less effort is necessary compared to proposal
 `A)`:
 
- * `rosdep`: choose between Python 2 and Python 3 dependencies.
+ * `rosdep`: choose between Python 2 and Python 3 dependencies; see the Rosdep_
+    section for more information.
 
  * `bloom` needs to generate releases for both Python versions in parallel.
    The user should only need to release each package once.
@@ -196,16 +190,16 @@ Similar goals and timeline to proposal `A)`, but with only a single set of
 installable debs, significantly lowering the complexity barrier for users and
 package deveopers/maintainers.
 
-The concept is that each installed package which supplies Python modules will be able
-to migrate to dual Python 2/3 support during ROS Melodic, such that leaf Python packages
-are able to opt into Python 3 any time during M or N, whenever their dependencies are
-ready to go.
+The concept is that each installed package which supplies Python modules will be
+able to migrate to dual Python 2/3 support during ROS Melodic, such that leaf
+Python packages are able to opt into Python 3 any time during Melodic or
+N-Turtle, whenever their dependencies are ready to go.
 
-This proposal offers flexibility to users, with the primary costs being the risk of
-user confusion or side effects around the "alternative python" shim, and the cost
-of dual-depending on all Python dependencies, which may frustrate users with limited
-disk who would prefer not to have both `python-numpy` and `python3-numpy` installed
-unncessarily.
+This proposal offers flexibility to users, with the primary costs being the risk
+of user confusion or side effects around the "alternative python" shim, and the
+cost of dual-depending on all Python dependencies, which may frustrate users
+with limited disk who would prefer not to have both `python-numpy` and
+`python3-numpy` installed unncessarily.
 
 The following timeline describes a transition over multiple ROS releases:
 
@@ -227,7 +221,7 @@ The following timeline describes a transition over multiple ROS releases:
      instead Python 2 or to use the dual-build behaviour.
 
  * ROS Melodic (May 2018, LTS):
- 
+
    * Debian packages using catkin_setup_python install to both
      `lib/python3/dist-packages/` and `lib/python2.7/dist-packages/`
    * Default behaviour of `catkin_install_python` (with an ambiguous
@@ -243,46 +237,81 @@ To support the proposal `C)` a few capabilities must be developed in catkin:
 
  * It will need to be updated with bilingual awareness around the
    `catkin_install_python` and `catkin_python_setup` functions.
-   
+
  * The existing `PYTHON_EXECUTABLE`, `PYTHON_LIBRARY`, and `PYTHON_INCLUDE_DIR`
    variables which may be used today to select the preferred Python will need to
-   be supplemented by a separate `PYTHON_ALT_*` vars which control which Python is
-   used for the second `setup.py` invocation. If the `PYTHON_ALT_*` vars are unset,
-   catkin will build only for the default Python (this would be default behaviour
-   in a source workspace, in order to not break Arch and other from-source systems
-   where `/usr/bin/python` is already Python 3).
-   
- * Similarly, Python nosetests will run twice if the `PYTHON_ALT_*` vars are set.
-   Perhaps a CMake function could be used to disable this behaviour, especially
-   for packages which migrate to Python 3 and don't want to receive test failures for
-   Python 2 issues. For example, `catkin_python_policy(ONLY_3)` or similar.
- 
- * In order to do the right thing with conventional `usr/bin/env python3` shebangs,
-   ROS Melodic will need to ship a small wrapper shim which mutates the `PYTHONPATH`
-   variable. This shim would live at `/opt/ros/melodic/bin/python3` and look like
-    ```
-    #!/bin/sh
-    PYTHONPATH=$(echo $PYTHONPATH | sed "s/lib\/python2\.7/lib\/python3/")
-    /usr/bin/python3 $*
-    ```
-   Similarly, ROS N would have to do the reverse operation in a `python2` shim. No
-   shim would be required for ROS O and beyond. This shim could be part of the
-   `catkin` package itself, or potentially live separately.
+   be supplemented by a separate `PYTHON_ALT_*` vars which control which Python
+   is used for the second `setup.py` invocation. If the `PYTHON_ALT_*` vars are
+   unset, catkin will build only for the default Python (this would be default
+   behaviour in a source workspace, in order to not break Arch and other
+   from-source systems where `/usr/bin/python` is already Python 3).
+
+ * Similarly, Python nosetests will run twice if the `PYTHON_ALT_*` vars are
+   set. Perhaps a CMake function could be used to disable this behaviour,
+   especially for packages which migrate to Python 3 and don't want to receive
+   test failures for Python 2 issues. For example,
+   `catkin_python_policy(ONLY_3)` or similar.
+
+ * In order to do the right thing with conventional `/usr/bin/env python3`
+   shebangs, ROS Melodic will need to ship a small wrapper shim which mutates
+   the `PYTHONPATH` variable. This shim would live at
+   `/opt/ros/melodic/bin/python3` and look like
+   ```
+   #!/bin/sh
+   PYTHONPATH=$(echo $PYTHONPATH | sed "s/lib\/python2\.7/lib\/python3/")
+   /usr/bin/python3 $*
+   ```
+   Similarly, ROS N-Turtle would have to do the reverse operation in a `python2`
+   shim. No shim would be required for ROS O-Turtle and beyond. This shim could
+   be part of the `catkin` package itself, or potentially live separately.
 
 And in other tools:
 
- * `rosdep`: choose between Python 2 and Python 3 dependencies.
- 
- * `bloom`: For the transitional releases (N and M), the default bloom behaviour will
-   be to depend on both the Python 2 and Python 3 versions of all Python dependencies.
+ * `rosdep`: choose between Python 2 and Python 3 dependencies; see the Rosdep_
+    section for more information.
 
- * `ros_buildfarm` should set the new `PYTHON_ALT_*` vars according to the release
-   plan given above.
-   
+ * `bloom`: For the transitional releases (N and M), the default bloom behaviour
+   will be to depend on both the Python 2 and Python 3 versions of all Python
+   dependencies.
+
+ * `ros_buildfarm` should set the new `PYTHON_ALT_*` vars according to the
+   release plan given above.
+
  * Packages which generate compiled Python extensions will require bespoke CMake
-   logic to ensure that these extensions are correctly built and installed twice.
-   Upon examining the individual cases, it's possible that the `catkin` package may
-   be able to provide some tooling to streamline this.
+   logic to ensure that these extensions are correctly built and installed
+   twice. Upon examining the individual cases, it's possible that the `catkin`
+   package may be able to provide some tooling to streamline this.
+
+Rosdep
+======
+
+To support any of the proposals above, rosdep must be updated to allow either
+Python 2 or Python 3 keys.
+
+Multiple different options can be considered for this:
+
+ #. Beside the `python.yaml` file create a `python3.yaml` file and let
+    `rosdep` choose between them.
+ #. Use different installers for Python 2 and Python 3 packages, e.g. `xenial`
+    and `xenial_python3`, and let `rosdep` choose between them.
+ #. Create explicit rosdep keys with a `python2` and `python3` prefix and use
+    them in the package manifest files with conditional dependencies as
+    specified in REP 149 [3]_.
+ #. A combination of 1. and 3., where the default dependency resolution for
+    rosdep depends on the ROS distribution in use, with an environment variable
+    to let users manually control it.  For instance, for a rosdep key of
+    `python-foo`, there would be an entry in `python.yaml` that resolves to
+    `python-foo` on Ubuntu, and an entry in `python3.yaml` that resolves to
+    `python3-foo` on Ubuntu.  On Melodic, rosdep would resolve dependencies
+    using the `python.yaml` file by default.  An environment variable called
+    `ROS_PYTHON_VERSION` would allow the user to force the use of `python3.yaml`
+    for dependency resolution for testing (though this requires a removal and
+    re-initialization of the entire rosdep database).  On N-Turtle, this would
+    be reversed and rosdep would resolve dependencies using the `python3.yaml`
+    file by default.  Additionally, there may be keys called `python2-foo` and
+    `python3-foo` that would allow package maintainers to support Python 2 and
+    Python 3 simultaneously in their package by utilizing conditional
+    dependencies in package format 3 [3]_.
 
 Conclusion
 ==========


### PR DESCRIPTION
Opening this draft for reference purposes. It describes the path for switching from Python 2 to Python 3 in ROS 1.

@ros-infrastructure/ros_team Please provide feedback to the current draft and feel free to fix / improve spelling / wording where you see fit and propose concrete additions if you think more information / context would be helpful.