### PR TITLE
REP 149: Add file attribution to license tag

### DIFF
--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -521,11 +521,13 @@ Attributes
 
  ``file="FILE"`` *(optional)*
 
-  A relative path from ``package.xml`` pointing the full license text.
+  A path relative to the ``package.xml`` file containing the full license text.
 
-  Some open source licenses require provision of the license text when a user
-  redistribute the software in a binary form [18]_. This attribution will help a
-  user or a tool find the right license text easily.
+  Many licenses require including the license text when
+  redistributing the software.
+  E.g. the ``Apache License, Version 2.0`` states in paragraph 4.1:
+  
+    "You must give any other recipients of the Work or Derivative Works a copy of this License"
 
   .. raw:: html
 
@@ -1133,8 +1135,6 @@ References
    (http://ros.org/reps/rep-0143)
 .. [17] ROS_DISTRO environment variable
   (https://github.com/ros/ros/blob/b202645dc6bea6d4b9ca408dc703c8c7cc8204d9/core/roslib/env-hooks/10.ros.sh.em#L16)
-.. [18] Licenses & Standards
-  (https://opensource.org/licenses)
 
 
 Copyright

--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -523,8 +523,8 @@ Attributes
 
   A path relative to the ``package.xml`` file containing the full license text.
 
-  Many licenses require including the license text when
-  redistributing the software.
+  Many licenses require including the license text when redistributing the
+  software.
   E.g. the ``Apache License, Version 2.0`` states in paragraph 4.1:
   
     "You must give any other recipients of the Work or Derivative Works a copy of this License"

--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -370,7 +370,7 @@ Example
     </description>
     <maintainer email="someone@example.com">Someone</maintainer>
 
-    <license file="LICENSE">BSD</license>
+    <license>BSD</license>
     <license file="LICENSE">LGPL</license>
 
     <url type="website">http://wiki.ros.org/my_package</url>

--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -370,8 +370,8 @@ Example
     </description>
     <maintainer email="someone@example.com">Someone</maintainer>
 
-    <license>BSD</license>
-    <license>LGPL</license>
+    <license file="LICENSE">BSD</license>
+    <license file="LICENSE">LGPL</license>
 
     <url type="website">http://wiki.ros.org/my_package</url>
     <url type="repository">http://www.github.com/my_org/my_package</url>
@@ -511,6 +511,25 @@ Commonly used license strings:
  - LGPLv3
  - MIT
  - Mozilla Public License Version 1.1
+
+Attributes
+''''''''''
+
+  .. raw:: html
+
+    <font color="blue">
+
+ ``file="FILE"`` *(optional)*
+
+  A relative path from ``package.xml`` pointing the full license text.
+
+  Some open source licenses require provision of the license text when a user
+  redistribute the software in a binary form [18]_. This attribution will help a
+  user or a tool find the right license text easily.
+
+  .. raw:: html
+
+    </font>
 
 <url> (multiple)
 ----------------
@@ -1114,6 +1133,8 @@ References
    (http://ros.org/reps/rep-0143)
 .. [17] ROS_DISTRO environment variable
   (https://github.com/ros/ros/blob/b202645dc6bea6d4b9ca408dc703c8c7cc8204d9/core/roslib/env-hooks/10.ros.sh.em#L16)
+.. [18] Licenses & Standards
+  (https://opensource.org/licenses)
 
 
 Copyright


### PR DESCRIPTION
Hi,
I would like to propose adding an optional file attribution to the license tag in REP 149.(#156,https://github.com/ros-infrastructure/bloom/issues/456). As I'm not familiar with REP, I would appreciate if you review the format first.
When the format is OK, I will call out for review to the discource.

The affected packages will be
* https://github.com/ros-infrastructure/catkin_pkg (package.xml parser for ROS1)
* https://github.com/ament/ament_package (package.xml parser for ROS2)
* https://github.com/ros-infrastructure/bloom (tool for binary packaging)

And I will provide PRs for the three.

Thanks is advance.
