### PR TITLE
Update to add recommendations for format 2

### DIFF
--- a/rep-0136.rst
+++ b/rep-0136.rst
@@ -201,6 +201,7 @@ Example package.xml
 Here is an example package.xml template for a third party package being released (using the recommended format 2 or format 3)::
 
   <?xml version="1.0"?>
+  <!-- Replace the "2" below with "3" when using format 3 -->
   <package format="2">
     <name>foo</name>
     <version>:{version}</version>

--- a/rep-0136.rst
+++ b/rep-0136.rst
@@ -77,7 +77,7 @@ The recommendation of this REP for releasing third party packages in the ROS com
 
  * Optionally, put the install rule for the package.xml into the actual upstream repository
 
-* Have a run_depend on catkin in the package.xml(s), or exec_depend when using format 2
+* Have an exec_depend on catkin in the package.xml(s) when using format 2 or 3, or run_depend when using the legacy format 1
 
 
 This provides the least intrusive, but most automated and correct method for releasing non-catkin packages through the ROS infrastructure.
@@ -198,7 +198,7 @@ There are updated bloom tutorials on the ROS wiki which explain how to release t
 Example package.xml
 -------------------
 
-Here is an example package.xml template for a third party package being released (using the recommended format 2)::
+Here is an example package.xml template for a third party package being released (using the recommended format 2 or format 3)::
 
   <?xml version="1.0"?>
   <package format="2">

--- a/rep-0136.rst
+++ b/rep-0136.rst
@@ -77,7 +77,7 @@ The recommendation of this REP for releasing third party packages in the ROS com
 
  * Optionally, put the install rule for the package.xml into the actual upstream repository
 
-* Have an exec_depend on catkin in the package.xml(s) when using format 2 or 3, or run_depend when using the legacy format 1
+* Have an exec_depend on catkin in the package.xml when using format 2, or a run_depend when using the legacy format 1
 
 
 This provides the least intrusive, but most automated and correct method for releasing non-catkin packages through the ROS infrastructure.
@@ -198,10 +198,9 @@ There are updated bloom tutorials on the ROS wiki which explain how to release t
 Example package.xml
 -------------------
 
-Here is an example package.xml template for a third party package being released (using the recommended format 2 or format 3)::
+Here is an example package.xml template for a third party package being released (using the recommended format 2)::
 
   <?xml version="1.0"?>
-  <!-- Replace the "2" below with "3" when using format 3 -->
   <package format="2">
     <name>foo</name>
     <version>:{version}</version>

--- a/rep-0136.rst
+++ b/rep-0136.rst
@@ -77,7 +77,7 @@ The recommendation of this REP for releasing third party packages in the ROS com
 
  * Optionally, put the install rule for the package.xml into the actual upstream repository
 
-* Have a run_depend on catkin in the package.xml(s)
+* Have a run_depend on catkin in the package.xml(s), or exec_depend when using format 2
 
 
 This provides the least intrusive, but most automated and correct method for releasing non-catkin packages through the ROS infrastructure.
@@ -198,7 +198,32 @@ There are updated bloom tutorials on the ROS wiki which explain how to release t
 Example package.xml
 -------------------
 
-Here is an example package.xml template for a third party package being released::
+Here is an example package.xml template for a third party package being released (using the recommended format 2)::
+
+  <?xml version="1.0"?>
+  <package format="2">
+    <name>foo</name>
+    <version>:{version}</version>
+    <description>The foo package</description>
+
+    <maintainer email="user@todo.todo">user</maintainer>
+    <license>BSD</license>
+
+    <buildtool_depend>cmake</buildtool_depend>
+
+    <build_depend>boost</build_depend>
+
+    <exec_depend>boost</exec_depend>
+    <exec_depend>catkin</exec_depend>
+
+    <export>
+      <build_type>cmake</build_type>
+    </export>
+  </package>
+
+In the above example the package is called foo, and the :{version} token is replaced with the version being released by bloom. If placing directly in the upstream branch, the version would need to be maintained by the developer manually.
+
+The following is the same example using the legacy format 1::
 
   <?xml version="1.0"?>
   <package>
@@ -220,8 +245,6 @@ Here is an example package.xml template for a third party package being released
       <build_type>cmake</build_type>
     </export>
   </package>
-
-In the above example the package is called foo, and the :{version} token is replaced with the version being released by bloom. If placing directly in the upstream branch, the version would need to be maintained by the developer manually.
 
 Example CMake package.xml Install Rule
 --------------------------------------


### PR DESCRIPTION
It seems that since the time this article was written, `run_depend` has been deprecated in favor of `exec_depend`, so it might helpful for new package maintainers to be instructed to use `exec_depend` instead of `run_depend`.

I'm not clear on whether we're permitted to revise these REPs, so feel free to reject this PR if this isn't the accepted procedure for this.