### PR TITLE
Update REP-142 with some fixes found during REP-150 review.

### DIFF
--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -65,13 +65,12 @@ In ROS Kinetic `ros_core` is extended to include `gennodejs`.
 ::
 
  - ros_core:
-      extends: [ros, ros_comm]
-      packages: [catkin, cmake_modules, common_msgs, console_bridge,
-                 gencpp, geneus(Jade and newer), gennodejs(Kinetic and newer),
-                 genlisp, genmsg, genpy, message_generation, message_runtime,
-                 rosbag_migration_rule, rosconsole_bridge,
-                 roscpp_core, rosgraph_msgs, roslisp, rospack,
-                 std_msgs, std_srvs]
+      packages: [catkin, cmake_modules, common_msgs, gencpp,
+                 geneus(Jade and newer), genlisp, genmsg,
+                 gennodejs(Kinetic and newer), genpy, message_generation,
+                 message_runtime, ros, ros_comm, rosbag_migration_rule,
+                 rosconsole_bridge, roscpp_core, rosgraph_msgs, roslisp,
+                 rospack, std_msgs, std_srvs]
 
 ROS Base
 ''''''''
@@ -84,9 +83,8 @@ It may not contain any GUI dependencies.
 
   - ros_base:
       extends: [ros_core]
-      packages: [actionlib, angles, bond_core, class_loader,
-                 dynamic_reconfigure, nodelet_core,
-                 pluginlib]
+      packages: [actionlib, bond_core, class_loader, dynamic_reconfigure,
+                 nodelet_core, pluginlib]
 
 Robot metapackage
 '''''''''''''''''
@@ -126,7 +124,7 @@ We discourage GUI dependencies in these stacks, if possible.
                  stage_ros]
 
   - viz:
-      extends: [robot]
+      extends: [ros_base]
       packages: [rqt_common_plugins, rqt_robot_plugins, rviz]
 
 Desktop variants
@@ -146,8 +144,9 @@ Both of these variants contain tutorials for the stacks they provide.
 
   - desktop:
       extends: [robot, viz]
-      packages: [common_tutorials, geometry_tutorials, ros_tutorials,
+      packages: [angles, common_tutorials, geometry_tutorials, ros_tutorials,
                  roslint, visualization_tutorials]
+
   - desktop_full:
       extends: [desktop, perception, simulators, urdf_tutorials]
 


### PR DESCRIPTION
In particular:

1.  Remove "extends" from "ros_core" definition, since extends
    is meant to be used for other meta-packages.
2.  Add "ros" and "ros_comm" into "ros_core" package list.
3.  Remove "console_bridge" from "ros_core" packages, since
    it is provided by the system since Trusty (Indigo).
4.  Move "angles" from "ros_base" to "desktop", since it is
    a dependency of common_tutorials.
5.  Make viz extend from "ros_base" instead of "robot".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>