### PR TITLE
One more fix to REP-142.

### DIFF
--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -148,7 +148,8 @@ Both of these variants contain tutorials for the stacks they provide.
                  roslint, visualization_tutorials]
 
   - desktop_full:
-      extends: [desktop, perception, simulators, urdf_tutorials]
+      extends: [desktop, perception, simulators]
+      packages: [urdf_tutorial]
 
 Institution-specific and robot-specific
 '''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
desktop_full currently "extends" urdf_tutorials, which is wrong
in two ways:

1.  "extends" should be used for meta-packages, not for packages,
    and thus this should be a package on desktop_full.
2.  The name is not "urdf_tutorials", but instead "urdf_tutorial".

Fix both of these.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>