### PR TITLE
REP153: adding metadata to the index file

### DIFF
--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -1,0 +1,94 @@
+REP: 153
+Title: ROS distribution files
+Author: Dirk Thomas <dthomas@osrfoundation.org>
+Status: Final
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 27-Oct-2018
+Post-History: 27-Oct-2018
+
+
+.. contents::
+
+Abstract
+========
+This REP updates the specification of the ROS distribution files facilitated in
+the building, packaging, testing and documenting process.
+
+The intention is to annotate ROS version with their major version (``1`` or
+``2``) and avoid the need to externally define and update a classification of
+ROS distribution names as ROS 1 or ROS 2.
+
+This REP is a revised version of REP 143 [1]_.
+It currently does not repeat the content of REP 143 but only states the
+differences.
+
+
+Specification
+=============
+
+Index file
+----------
+
+* distributions
+
+  * distribution:
+
+    * ros_version: an optional integer describing the major version of ROS
+      (either ``1`` or ``2``). If not set the value defaults to ``1``.
+
+    The files are read in the order they are listed and entries in later
+    distribution files are overwriting entries from previous distribution
+    files.
+    This can be used to override specific repositories with either a forked
+    variant or a specific version number.
+    ``bloom`` will create pull requests against the last distribution file
+    since even when the repository is present in any of the other distribution
+    files the "overlaying" version should be stored in the last one.
+
+  * release_builds / source_builds / doc_builds: are being removed since they
+    only contain information relevant to the buildfarm
+
+* version: version number, this REP describes version 4 (instead of version 3
+  described in REP 143 [1]_, version 2 described in REP 141 [2]_ and version 1
+  described in REP 137 [3]_)
+
+
+Reference implementation
+------------------------
+This REP is to be implemented in version 0.7 of the Python package *rosdistro*.
+It will serve as a reference implementation for this REP.
+A draft implementation can be found in [4]_.
+
+
+Compatibility issues
+====================
+
+The draft implementation of rosdistro is able to parse multiple index format
+versions: 2, 3 as well as 4.
+
+As soon as the new version of 'rosdistro' is released and the ROS 2
+distributions have been moved from the forked repository into the
+'ros/rosdistro' repository [5]_ the new field is being used to annotate the ROS
+2 distributions.
+Any client accessing trying to access the data with an old 'rosdistro'
+version will get an error message like this:
+
+::
+
+  Unable to handle 'index' format version '4', please update rosdistro...
+
+
+References
+==========
+.. [1] REP 143: http://www.ros.org/reps/rep-0143.html
+.. [2] REP 141: http://www.ros.org/reps/rep-0141.html
+.. [3] REP 137: http://www.ros.org/reps/rep-0137.html
+.. [4] Patch to python-rosdistro:
+  https://github.com/ros-infrastructure/rosdistro/pull/124
+.. [5] ROS distro: https://github.com/ros/rosdistro/
+
+
+Copyright
+=========
+This document has been placed in the public domain.

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -15,13 +15,37 @@ Abstract
 This REP updates the specification of the ROS distribution files facilitated in
 the building, packaging, testing and documenting process.
 
-The intention is to annotate ROS version with their major version (``1`` or
-``2``) and avoid the need to externally define and update a classification of
-ROS distribution names as ROS 1 or ROS 2.
+The intention is to annotate a ROS distribution with more information (like the
+"major" version (``1`` or``2``) to avoid the need to externally define and
+update these metadata.
 
 This REP is an extension to the file format defined in REP 143[1]_.
 It currently does not repeat the content of REP 143 but only states the
 differences.
+
+
+Motivation
+==========
+
+For the following use cases additional metadata is currently necessary:
+
+A. The ROS buildfarm has to distinguish ROS 1 distributions from ROS 2
+   distributions because they require different dependencies to build a
+   workspace.
+   E.g. for ROS 1 workspaces ``catkin`` needs to be installed - even
+   for plain CMake packages - since the tool ``catkin_make_isolated`` is
+   provided by it.
+   For ROS 2 the package ``ros_workspace`` needs it provides the setup files
+   for the workspace and therefore the environment necessary to find resources.
+
+B. The ROS wiki shows the list of currently active ROS distributions.
+   Since the ``rosdistro`` contains all ROS distros - EOLed ones as well as
+   upcoming distributions before their release date.
+
+In both cases the missing metadata is currently being hard coded in the source
+code and needs to be updated with every new ROS release.
+Therefore this REP aims to add the necessary metadata about a ROS distribution
+into the ``rosdistro`` instead.
 
 
 Specification
@@ -34,20 +58,19 @@ Index file
 
   * distribution:
 
-    * ros_version: an optional integer describing the major version of ROS
-      (either ``1`` or ``2``). If not set the value defaults to ``1``.
+    * distribution_status: an optional string describing the status of a ROS
+      distribution.
+      For the use case *B.* the semantic of the following values is defined:
 
-    The files are read in the order they are listed and entries in later
-    distribution files are overwriting entries from previous distribution
-    files.
-    This can be used to override specific repositories with either a forked
-    variant or a specific version number.
-    ``bloom`` will create pull requests against the last distribution file
-    since even when the repository is present in any of the other distribution
-    files the "overlaying" version should be stored in the last one.
+      * ``prerelease``: An upcoming distribution which hasn't been released yet
+      * ``active``: A distribution which has been released and is actively
+        being supported
+      * ``end-of-life``: A distribution which has reached its end of life
 
-  * release_builds / source_builds / doc_builds: are being removed since they
-    only contain information relevant to the buildfarm
+    * distribution_type: an optional string describing the type of the ROS
+      distribution.
+      For use case *A.* the values ``ros1`` and ``ros2`` will be used to
+      distinguish the major ROS version.
 
 * version: version number, this REP describes version 4 (instead of version 3
   described in REP 143 [1]_, version 2 described in REP 141 [2]_ and version 1

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -19,7 +19,7 @@ The intention is to annotate ROS version with their major version (``1`` or
 ``2``) and avoid the need to externally define and update a classification of
 ROS distribution names as ROS 1 or ROS 2.
 
-This REP is a revised version of REP 143 [1]_.
+This REP is an extension to the file format defined in REP 143[1]_.
 It currently does not repeat the content of REP 143 but only states the
 differences.
 

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -71,7 +71,7 @@ As soon as the new version of 'rosdistro' is released and the ROS 2
 distributions have been moved from the forked repository into the
 'ros/rosdistro' repository [5]_ the new field is being used to annotate the ROS
 2 distributions.
-Any client accessing trying to access the data with an old 'rosdistro'
+Any client trying to access the data with an old 'rosdistro'
 version will get an error message like this:
 
 ::

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -90,23 +90,41 @@ It will serve as a reference implementation for this REP.
 A draft implementation can be found in [4]_.
 
 
-Compatibility issues
-====================
+Compatibility considerations
+============================
 
 The draft implementation of rosdistro is able to parse multiple index format
 versions: 2, 3 as well as 4.
 
-As soon as the new version of 'rosdistro' is released and the ROS 2
-distributions have been moved from the forked repository into the
-'ros/rosdistro' repository [5]_ the new field is being used to annotate the ROS
-2 distributions.
-Any client trying to access the data with an old 'rosdistro'
-version will get an error message like this:
+If the version of the existing ``index.yaml`` file would be bumped that would
+require every user to update to the latest version of the Python package
+``rosdistro``.
+While generating some friction it is especially a problem on some systems (e.g.
+Debian) which might not provide a newer version in stable distributions.
 
-::
+Therefore the existing index file isn't being changed but a sibling file named
+``index-v4.yaml`` is being added.
+The file has the same content except that is uses version 4 as specified in
+this document and includes the additional metadata fields.
 
-  Unable to handle 'index' format version '4', please update rosdistro...
+To make use of the new index file the new version of the Python package will
+update the default URL to point to the v4 file.
 
+This provides a smooth transition for all users: users using the old version of
+the Python package can continue to use it as is, users updating to the newer
+version will benefit from the additional metadata.
+Python code using the ``rosdistro`` API can easily check if the metadata is
+present and if yes use it.
+If desired other Python packages can explicily depend on the newer version to
+ensure the v4 index is being used.
+
+bloom
+-----
+
+Beside using the ``rosdistro`` API ``bloom`` also includes an explicit check
+for the version of the index file [5]_.
+Therefore a new patch release of ``bloom`` is required to also support the new
+version 4 [6]_.
 
 References
 ==========
@@ -115,7 +133,8 @@ References
 .. [3] REP 137: http://www.ros.org/reps/rep-0137.html
 .. [4] Patch to python-rosdistro:
   https://github.com/ros-infrastructure/rosdistro/pull/124
-.. [5] ROS distro: https://github.com/ros/rosdistro/
+.. [5] bloom asserting the index file version: https://github.com/ros-infrastructure/bloom/blob/d8be9d1d3469f00f936ad6e4869b847c5a6f8962/bloom/commands/release.py#L221-L223
+.. [8] bloom PR to support v4 https://github.com/ros-infrastructure/bloom/pull/493
 
 
 Copyright

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -73,6 +73,11 @@ Index file
       For use case *1.* the values ``ros1`` and ``ros2`` will be used to
       distinguish the major ROS version.
 
+    As of version 4 unknown keys should be ignored (instead of resulting in an
+    error).
+    This will allow future additions in a backward compatible way without the
+    need to bump the version of the file.
+
 * version: version number, this REP describes version 4 (instead of version 3
   described in REP 143 [1]_, version 2 described in REP 141 [2]_ and version 1
   described in REP 137 [3]_)

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -15,9 +15,9 @@ Abstract
 This REP updates the specification of the ROS distribution files facilitated in
 the building, packaging, testing and documenting process.
 
-The intention is to annotate a ROS distribution with more information (like the
-"major" version (``1`` or ``2``) to avoid the need to externally define and
-update these metadata.
+The intention is to annotate a ROS distribution with more information,
+such as whether the distribution should use ROS 1 or ROS 2 semantics,
+to avoid the need to externally define and update these metadata.
 
 This REP is an extension to the file format defined in REP 143[1]_.
 It currently does not repeat the content of REP 143 but only states the

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Oct-2018
-Post-History: 27-Oct-2018
+Post-History: 06-Nov-2018
 
 
 .. contents::

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -33,10 +33,11 @@ A. The ROS buildfarm has to distinguish ROS 1 distributions from ROS 2
    distributions because they require different dependencies to build a
    workspace.
    E.g. for ROS 1 workspaces ``catkin`` needs to be installed - even
-   for plain CMake packages - since the tool ``catkin_make_isolated`` is
-   provided by it.
-   For ROS 2 the package ``ros_workspace`` needs it provides the setup files
-   for the workspace and therefore the environment necessary to find resources.
+   for plain CMake packages - since it provides the workspace level setup
+   files.
+   For ROS 2 the package ``ros_workspace`` is needed since it provides the
+   setup files for the workspace and therefore the environment necessary to
+   find resources.
 
 B. The ROS wiki shows the list of currently active ROS distributions.
    Since the ``rosdistro`` contains all ROS distros - EOLed ones as well as

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Oct-2018
-Post-History: 06-Nov-2018
+Post-History: 09-Nov-2018
 
 
 .. contents::

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -134,7 +134,7 @@ References
 .. [4] Patch to python-rosdistro:
   https://github.com/ros-infrastructure/rosdistro/pull/124
 .. [5] bloom asserting the index file version: https://github.com/ros-infrastructure/bloom/blob/d8be9d1d3469f00f936ad6e4869b847c5a6f8962/bloom/commands/release.py#L221-L223
-.. [8] bloom PR to support v4 https://github.com/ros-infrastructure/bloom/pull/493
+.. [6] bloom PR to support v4 https://github.com/ros-infrastructure/bloom/pull/493
 
 
 Copyright

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -29,7 +29,7 @@ Motivation
 
 For the following use cases additional metadata is currently necessary:
 
-A. The ROS buildfarm has to distinguish ROS 1 distributions from ROS 2
+1. The ROS buildfarm has to distinguish ROS 1 distributions from ROS 2
    distributions because they require different dependencies to build a
    workspace.
    E.g. for ROS 1 workspaces ``catkin`` needs to be installed - even
@@ -39,7 +39,7 @@ A. The ROS buildfarm has to distinguish ROS 1 distributions from ROS 2
    setup files for the workspace and therefore the environment necessary to
    find resources.
 
-B. The ROS wiki shows the list of currently active ROS distributions.
+2. The ROS wiki shows the list of currently active ROS distributions.
    Since the ``rosdistro`` contains all ROS distros - EOLed ones as well as
    upcoming distributions before their release date.
 
@@ -61,7 +61,7 @@ Index file
 
     * distribution_status: an optional string describing the status of a ROS
       distribution.
-      For the use case *B.* the semantic of the following values is defined:
+      For the use case *2.* the semantic of the following values is defined:
 
       * ``prerelease``: An upcoming distribution which hasn't been released yet
       * ``active``: A distribution which has been released and is actively
@@ -70,7 +70,7 @@ Index file
 
     * distribution_type: an optional string describing the type of the ROS
       distribution.
-      For use case *A.* the values ``ros1`` and ``ros2`` will be used to
+      For use case *1.* the values ``ros1`` and ``ros2`` will be used to
       distinguish the major ROS version.
 
 * version: version number, this REP describes version 4 (instead of version 3

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -16,7 +16,7 @@ This REP updates the specification of the ROS distribution files facilitated in
 the building, packaging, testing and documenting process.
 
 The intention is to annotate a ROS distribution with more information (like the
-"major" version (``1`` or``2``) to avoid the need to externally define and
+"major" version (``1`` or ``2``) to avoid the need to externally define and
 update these metadata.
 
 This REP is an extension to the file format defined in REP 143[1]_.


### PR DESCRIPTION
Related to ros2/ros_buildfarm_config#12.

Since the major ROS version is specific to a distribution it should be annotated in the index file (rather than in the buildfarm configuration).

The current implementation would fail to parse newer files containing the `ros_version` (with the same format version) due to this check: https://github.com/ros-infrastructure/rosdistro/blob/df28723d0d2e12b52cd81867d03ed4c979187e3a/src/rosdistro/index.py#L80

Therefore leveling the version of the index format is the cleaner way to go. Then users get a clear error message that they need a new rosdistro version to parse the new format.

This will pave the path to reintegrate the [forked ROS 2 rosdistro](https://github.com/ros2/rosdistro) into the [ROS (1) rosdistro repo](https://github.com/ros/rosdistro/).