### PR TITLE
[rep-2000] Resolve TODO about binary archives

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -209,7 +209,7 @@ Targeted platforms:
 
 
 " * " Individual binary packages are not currently available for these platforms.
-Binary releases are provided in the form of {comprehensive,omnibus} (TODO: choose a word here that isn't "fat") archives.
+Binary releases are provided as a single archive per platform containing all packages in [this repos file](https://github.com/ros2/ros2/blob/master/ros2.repos).
 
 " [s] " Compilation from source, the ROS buildfarm will not produce any binary packages for these platforms.
 


### PR DESCRIPTION
The TODO was about avoiding describing the archive as "fat". This re-words the sentence and removes the TODO.