### PR TITLE
Include sros2 in ros-core

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -58,7 +58,7 @@ It may not contain any GUI dependencies.
                  poco_vendor, rcl, rcl_interfaces, rclcpp, rclpy,
                  rcutils, rmw, rmw_implementation, ros2cli, rosidl,
                  rosidl_dds, rosidl_defaults, rosidl_python, rosidl_typesupport,
-                 ros_environment, tinyxml2_vendor, uncrustify]
+                 ros_environment, sros2, tinyxml2_vendor, uncrustify]
       And at least one of the following rmw_implementation:
       - Fast-RTPS: [Fast-CDR, Fast-RTPS, rmw_fastrtps]
       - Connext: [rmw_connext, rosidl_typesupport_connext]
@@ -94,7 +94,7 @@ It provides all commonly used libraries as well as visualization tools and tutor
       packages: [angles, demos, depthimage_to_laserscan, example_interfaces,
                  examples, joystick_drivers, laser_geometry,
                  navigation_msgs, pcl_conversions, realtime_support,
-                 resource_retriever, rviz, sros2, teleop_twist_joy,
+                 resource_retriever, rviz, teleop_twist_joy,
                  teleop_twist_keyboard, tlsf, vision_opencv]
 
 

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -5,7 +5,7 @@ Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 16-Jul-2018
-Post-History: 15-Mar-2019
+Post-History: 17-Sep-2018, 15-Mar-2019
 
 
 Abstract

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -1,11 +1,11 @@
 REP: 2001
 Title: ROS Bouncy and Newer Variants
-Author: Tully Foote <tfoote@openrobotics.org>, Mikael Arguedas <mikael@openrobotics.org>
+Author: Tully Foote <tfoote@openrobotics.org>, Mikael Arguedas <mikael@openrobotics.org>, Ruffin White <roxfoxpox@gmail.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 16-Jul-2018
-Post-History: 17-Sep-2018
+Post-History: 15-Mar-2019
 
 
 Abstract


### PR DESCRIPTION
Facilitate default security by including sros2 in the CLI provided through ros-core, or at very least ros-base. Having sros CLI shipped with crystal core packages would helpful when using the official docker images derived from the ros-core and ros-base variants with security.

Related: https://github.com/ros2/variants/pull/10