### PR TITLE
Add "condition" Attribute to package_format3.xsd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 # command to install dependencies
 install:
   - pip install docutils
+  - pip install xmlschema
 # command to run tests
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ SUBDIRS=$(wildcard rep-????)
 
 TARGETS=$(REPS:.rst=.html) rep-0000.html
 
-all: rep-0000.rst $(TARGETS)
+all: rep-0000.rst $(TARGETS) $(XMLVALID)
 
 $(TARGETS): rep2html.py
+
+$(XMLVALID): xmlValid.py
 
 rep-0000.rst: $(REPS)
 	$(PYTHON) genrepindex.py .

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,15 @@ SUBDIRS=$(wildcard rep-????)
 
 TARGETS=$(REPS:.rst=.html) rep-0000.html
 
-all: rep-0000.rst $(TARGETS) $(XMLVALID)
+all: rep-0000.rst $(TARGETS) xsdvalid
 
 $(TARGETS): rep2html.py
 
-$(XMLVALID): xmlValid.py
-
 rep-0000.rst: $(REPS)
 	$(PYTHON) genrepindex.py .
+
+xsdvalid:
+	$(PYTHON) xsdValid.py
 
 clean:
 	-rm *.html

--- a/xsd/package_common.xsd
+++ b/xsd/package_common.xsd
@@ -81,23 +81,6 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:complexType name="DependencyType">
-    <xs:simpleContent>
-      <xs:extension base="xs:token">
-        <!-- The dependency must have a version less then the specified limit. -->
-        <xs:attribute name="version_lt" type="VersionLimitType" use="optional"/>
-        <!-- The dependency must have a version less then or equal to the specified limit. -->
-        <xs:attribute name="version_lte" type="VersionLimitType" use="optional"/>
-        <!-- The dependency must have a version equal to the specified limit. -->
-        <xs:attribute name="version_eq" type="VersionLimitType" use="optional"/>
-        <!-- The dependency must have a version greater then or equal to the specified limit. -->
-        <xs:attribute name="version_gte" type="VersionLimitType" use="optional"/>
-        <!-- The dependency must have a version greater then the specified limit. -->
-        <xs:attribute name="version_gt" type="VersionLimitType" use="optional"/>
-      </xs:extension>
-    </xs:simpleContent>
-  </xs:complexType>
-
   <xs:complexType name="ExportType">
     <xs:sequence>
       <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>

--- a/xsd/package_format1.xsd
+++ b/xsd/package_format1.xsd
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="package_common.xsd"/>
+
+  <xs:complexType name="DependencyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <!-- The dependency must have a version less then the specified limit. -->
+        <xs:attribute name="version_lt" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version less then or equal to the specified limit. -->
+        <xs:attribute name="version_lte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version equal to the specified limit. -->
+        <xs:attribute name="version_eq" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then or equal to the specified limit. -->
+        <xs:attribute name="version_gte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then the specified limit. -->
+        <xs:attribute name="version_gt" type="VersionLimitType" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:element name="package">
     <xs:annotation>
       <xs:documentation>

--- a/xsd/package_format2.xsd
+++ b/xsd/package_format2.xsd
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="package_common.xsd"/>
+
+  <xs:complexType name="DependencyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <!-- The dependency must have a version less then the specified limit. -->
+        <xs:attribute name="version_lt" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version less then or equal to the specified limit. -->
+        <xs:attribute name="version_lte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version equal to the specified limit. -->
+        <xs:attribute name="version_eq" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then or equal to the specified limit. -->
+        <xs:attribute name="version_gte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then the specified limit. -->
+        <xs:attribute name="version_gt" type="VersionLimitType" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:element name="package">
     <xs:annotation>
       <xs:documentation>

--- a/xsd/package_format3.xsd
+++ b/xsd/package_format3.xsd
@@ -2,6 +2,23 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="package_common.xsd"/>
 
+  <xs:complexType name="DependencyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <!-- The dependency must have a version less then the specified limit. -->
+        <xs:attribute name="version_lt" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version less then or equal to the specified limit. -->
+        <xs:attribute name="version_lte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version equal to the specified limit. -->
+        <xs:attribute name="version_eq" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then or equal to the specified limit. -->
+        <xs:attribute name="version_gte" type="VersionLimitType" use="optional"/>
+        <!-- The dependency must have a version greater then the specified limit. -->
+        <xs:attribute name="version_gt" type="VersionLimitType" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:complexType name="VersionWithOptionalCompatibilityType">
     <xs:simpleContent>
       <xs:extension base="VersionType">

--- a/xsd/package_format3.xsd
+++ b/xsd/package_format3.xsd
@@ -2,6 +2,20 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="package_common.xsd"/>
 
+  <xs:complexType name="ConditionalType">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attribute name="condition" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:pattern value="[$A-Za-z0-9_\s&lt;&gt;=]*"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:complexType name="DependencyType">
     <xs:simpleContent>
       <xs:extension base="xs:token">
@@ -15,6 +29,13 @@
         <xs:attribute name="version_gte" type="VersionLimitType" use="optional"/>
         <!-- The dependency must have a version greater then the specified limit. -->
         <xs:attribute name="version_gt" type="VersionLimitType" use="optional"/>
+        <xs:attribute name="condition" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:pattern value="[$A-Za-z0-9_\s&lt;&gt;=]*"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -73,8 +94,8 @@
           <xs:element type="DependencyType" name="replace"/>
         </xs:choice>
 
-        <xs:element name="group_depend" type="xs:token" minOccurs="0" maxOccurs="unbounded"/>
-        <xs:element name="member_of_group" type="xs:token" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="group_depend" type="ConditionalType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="member_of_group" type="ConditionalType" minOccurs="0" maxOccurs="unbounded"/>
 
         <xs:element name="export" type="ExportType" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>

--- a/xsdValid.py
+++ b/xsdValid.py
@@ -3,9 +3,8 @@
 import xmlschema
 
 format1 = xmlschema.XMLSchema('xsd/package_format1.xsd')
+print("'xsd/package_format1.xsd' file is valid.")
 format2 = xmlschema.XMLSchema('xsd/package_format2.xsd')
+print("'xsd/package_format2.xsd' file is valid.")
 format3 = xmlschema.XMLSchema('xsd/package_format3.xsd')
-
-print("Format1: ", format1.validity)
-print("Format2: ", format2.validity)
-print("Format3: ", format3.validity)
+print("'xsd/package_format3.xsd' file is valid.")

--- a/xsdValid.py
+++ b/xsdValid.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+
+import xmlschema
+
+format1 = xmlschema.XMLSchema('xsd/package_format1.xsd')
+format2 = xmlschema.XMLSchema('xsd/package_format2.xsd')
+format3 = xmlschema.XMLSchema('xsd/package_format3.xsd')
+
+print("Format1: ", format1.validity)
+print("Format2: ", format2.validity)
+print("Format3: ", format3.validity)


### PR DESCRIPTION
As a consequence of REP-149, several elements in the package.xml specification have an added "condition" attribute. This has already been addressed in [rosdep](https://github.com/ros-infrastructure/rosdep/issues/653) and is being addressed in [bloom](https://github.com/ros-infrastructure/bloom/pull/519) but the XSDs needed to be updated for tools like xmllint to be able to validate new package.xml files. This PR addresses those changes.

All package_formatN.xml files validated independently and against existing package.xml files using `xmllint`.