### PR TITLE
REP 2002: adding a rolling ROS distribution

### DIFF
--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -41,7 +41,6 @@ A snaphot of the source distro will be captured, most likely a git commit-ish.
 The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.
 The tool will then iterate through all repositories in the snapshot of the source rosdistro and attempt to automatically run bloom release on the package at the specific version in the snapshot.
 If it fails the maintainer will be needed to resolve any issues.
-The tool will continue skipping that package and all downstream repositories.
 
 If the process gets interrupted the migration tool can be rerun with the same source snapshot and target rosdistro.
 The migration tool will skip any package already in the target rosdistro.

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -45,7 +45,7 @@ If a package is prevented from being automatically released into the stable dist
 Updating the rolling release platforms
 --------------------------------------
 
-The rolling release is intended to remain availabe indefinitely and so will not be retired or reach end-of-support status without an update to this REP and the ROS distribution release process.
+The rolling release is intended to remain available indefinitely and so will not be retired or reach end-of-support status without an update to this REP and the ROS distribution release process.
 However, this does mean that platform changes during the life of the rolling distribution are going to occur and the rolling release may target platforms that are themselves unstable or in a pre-release state.
 When a platform change is coming, the intended date of change will be announced ahead of time.
 Once the platforms have been updated, everything currently in the rolling release will be automatically re-released via bloom to target the updated release platforms.

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -39,13 +39,13 @@ To make a new rosdistro, target, from an existing rosdistro, source. An automate
 
 A snaphot of the source distro will be captured, most likely a git commit-ish.
 The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.
-The tool will then iterate through all packages in the snapshot of the source rosdistro and attempt to automatically run bloom release on the package at the specific version in the snapshot.
+The tool will then iterate through all repositories in the snapshot of the source rosdistro and attempt to automatically run bloom release on the package at the specific version in the snapshot.
 If it fails the maintainer will be needed to resolve any issues.
-The tool will continue skipping that package and all downstream packages.
+The tool will continue skipping that package and all downstream repositories.
 
 If the process gets interrupted the migration tool can be rerun with the same source snapshot and target rosdistro.
 The migration tool will skip any package already in the target rosdistro.
-The rerun is valuable in cases when a maintainer has resolved an an issue and many more downstream packages are unblocked, as well as if the operation gets interrupted.
+The rerun is valuable in cases when a maintainer has resolved an an issue and many more downstream repositories are unblocked, as well as if the operation gets interrupted.
 
 After the snapshot is taken maintainers must make releases for both the source rosdistro and target rosdistro as develoment is considered forked.
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -91,14 +91,13 @@ ros_buildfarm will require additional jobs that can re-run bloom unattended when
 Bloom may require some changes to allow it to be run unattended with pre-selected answers to interactive questions.
 
 
-Managing build farm writable release repositories
+Managing build farm-writable release repositories
 -------------------------------------------------
 
-In order to allow bloom to be run in an automated fashion the release repository must be writeable by the build farm agents.
-Release repositories may be hosted in a standard location such as the ros-gbp or ros2-gbp organizations on GitHub.
-If a repository isn't writeable by the build farm the release repository may be forked to a standard location for the purpose of making the release.
-Some form of breadcrumb will be left so that the previous release repository is noted.
-
+In order to allow bloom to be run in an automated fashion the release repository must be writeable by Open Robotics automation tools or staff.
+Therefore release repositories used by the rolling release distribution must be hosted in a standard location such as the ros-gbp or ros2-gbp organizations on GitHub.
+Release repositories outside the standard location will be forked to the standard location.
+Administrative access to release repositories will be granted to package mantainers for regular releases.
 
 
 References

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -54,9 +54,8 @@ Once the platforms have been updated, everything currently in the rolling releas
 Bootstrapping the rolling release
 ---------------------------------
 
-The first release of the rolling rosdistro will use the same procedure we've used for all stable rosdistros previously.
-Packages will be released via bloom into an empty distribution until the distribution is relatively complete.
-Package maintainers may then choose to make releases into the rolling rosdistro.
+The initial creation of the rolling rosdistro will use the rolling release tools "in reverse" to create the rolling release from the May 2020 ROS 2 Foxy Fitzroy release.
+Package maintainers may then continue to release into either or both Foxy and the rolling release distribution independently.
 
 
 Recommendations for package maintainers

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -35,7 +35,7 @@ Release process
 Automated release migration tool
 --------------------------------
 
-To make a new rosdistro, target, from an existing rosdistro, source. An automated migration tool is available to to reduce manual labor.
+To make a new rosdistro, target, from an existing rosdistro, source, an automated migration tool is available to reduce manual labor.
 
 A snaphot of the source distro will be captured, most likely a git commit-ish.
 The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -18,7 +18,7 @@ It also describes how future releases of ROS 2 may be produced by taking a snaps
 Motivation
 ==========
 
-In order to reduce the workload of Open Robotics staff and individual package maintainers when bootstrapping new ROS releases a rolling ROS distribution will be created to serve as the foundation for subsequent stable ROS distributions.
+Create a rolling ROS distribution to serve as the foundation for subsequent stable ROS distributions in order to reduce the workload of Open Robotics staff and individual package maintainers when bootstrapping new ROS releases.
 
 
 Support status

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -72,7 +72,7 @@ After which the migration tool can be invoked with the target and source rosdist
 Bootstrapping the rolling release
 ---------------------------------
 
-The initial creation of the rolling rosdistro will use the rolling release tools "in reverse" to create the rolling release from the May 2020 ROS 2 Foxy Fitzroy release.
+The initial creation of the rolling rosdistro will use the rolling release tools "in reverse" to create the rolling release from the June 2020 ROS 2 Foxy Fitzroy release.
 Package maintainers may then continue to release into either or both Foxy and the rolling release distribution independently.
 
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -38,7 +38,7 @@ Releasing stable ROS distributions from a rolling release
 When a new stable release is being prepared, the rolling release will be used as a staging ground to prepare that release.
 Updates and new package releases made to the rolling release will be propagated automatically to the stable release.
 At an announced time prior to the official stable release, the stable distribution will be created and packages with successful builds on the rolling release will be automatically released via bloom into the stable release.
-Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release may not be automatically propagated to the stable release.
+Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release will not be automatically propagated to the stable release.
 If a package is prevented from being automatically released into the stable distribution due to a dependency being unavailable in the stable distribution, that package may be automatically re-bloomed when the dependency becomes available in the stable distribution.
 
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -38,7 +38,8 @@ Releasing stable ROS distributions from a rolling release
 When a new stable release is being prepared, the rolling release will be used as a staging ground to prepare that release.
 Updates and new package releases made to the rolling release will be propagated automatically to the stable release.
 At an announced time prior to the official stable release, the stable distribution will be created and packages with successful builds on the rolling release will be automatically released via bloom into the stable release.
-Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release may not be automatically propagated to the stable release although 
+Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release may not be automatically propagated to the stable release.
+If a package is prevented from being automatically released into the stable distribution due to a dependency being unavailable in the stable distribution, that package may be automatically re-bloomed when the dependency becomes available in the stable distribution.
 
 
 Updating the rolling release platforms

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -5,7 +5,7 @@ Status: Draft
 Type: Informational
 Content-Type: text/x-rst
 Created: 05-Sep-2019
-Post-History: 05-Sep-2019, 03-Oct-2019
+Post-History: 05-Sep-2019, 03-Oct-2019, 18-Oct-2019
 
 
 Abstract
@@ -112,6 +112,12 @@ References
 
 .. [3] bloom repository
    (https://github.com/ros-infrastructure/bloom)
+
+.. [4] Time for reviewing ROS distro release cycle on Discourse
+   (https://discourse.ros.org/t/time-for-reviewing-ros-distro-release-cycle/2744/3)
+
+.. [5] Proposed changes to the ROS releases discussion on Discourse
+   (https://discourse.ros.org/t/proposed-changes-to-the-ros-releases/4736)
 
 
 Copyright

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -65,7 +65,7 @@ However, this does mean that platform changes during the life of the rolling dis
 When a platform change is coming, the intended date of change will be announced ahead of time.
 
 The platform change is a unique invocation of the migration tool where the source and target rosdistro will be the same.
-To do this the person managing the migration will take the snapshot of the source rosdistro and then clear it's contents as well as updating the target platforms.
+To do this the person managing the migration will take the snapshot of the source rosdistro and then clear its contents, as well as updating the target platforms.
 After which the migration tool can be invoked with the target and source rosdistro as the same, because the source rosdistro will be leveraging the snapshot.
 
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -32,14 +32,30 @@ During the pre-release phase for stable ROS distributions releases in the rollin
 Release process
 ===============
 
+Automated release migration tool
+--------------------------------
+
+To make a new rosdistro, target, from an existing rosdistro, source. An automated migration tool is available to to avoid manual labor.
+
+A snaphot of the source distro will be captured, most likely a git commit-ish.
+The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.
+The tool will then iterate through all packages in the snapshot of the source rosdistro and attempt to automatically run bloom release on the package at the specific version in the snapshot.
+If it fails the maintainer will be needed to resolve any issues.
+The tool will continue skipping that package and all downstream packages.
+
+If the process gets interrupted the migration tool can be rerun with the same source snapshot and target rosdistro.
+The migration tool will skip any package already in the target rosdistro.
+The rerun is valuable in cases when a maintainer has resolved an an issue and many more downstream packages are unblocked, as well as if the operation gets interrupted.
+
+After the snapshot is taken maintainers must make releases for both the source rosdistro and target rosdistro as develoment is considered forked.
+
+
 Releasing stable ROS distributions from a rolling release
 ---------------------------------------------------------
 
-When a new stable release is being prepared, the rolling release will be used as a staging ground to prepare that release.
-Updates and new package releases made to the rolling release will be propagated automatically to the stable release.
-At an announced time prior to the official stable release, the stable distribution will be created and packages with successful builds on the rolling release will be automatically released via bloom into the stable release.
-Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release will not be automatically propagated to the stable release.
-If a package is prevented from being automatically released into the stable distribution due to a dependency being unavailable in the stable distribution, that package may be automatically re-bloomed when the dependency becomes available in the stable distribution.
+Prior to formally starting development for the next stable release, the rolling release will be used as a staging ground for new content.
+At an announced time prior to start the official stable release, a snapshot of the rolling release will be created and will be used to boostrap the next stable release development process.
+This will be automated by the migration tool outlined above.
 
 
 Updating the rolling release platforms
@@ -48,7 +64,10 @@ Updating the rolling release platforms
 The rolling release is intended to remain available indefinitely and so will not be retired or reach end-of-support status without an update to this REP and the ROS distribution release process.
 However, this does mean that platform changes during the life of the rolling distribution are going to occur and the rolling release may target platforms that are themselves unstable or in a pre-release state.
 When a platform change is coming, the intended date of change will be announced ahead of time.
-Once the platforms have been updated, everything currently in the rolling release will be automatically re-released via bloom to target the updated release platforms.
+
+The platform change is a unique invocation of the migration tool where the source and target rosdistro will be the same.
+To do this the person managing the migration will take the snapshot of the source rosdistro and then clear it's contents as well as updating the targetget platforms.
+After which the migration tool can be invoked with the target and source rosdistro as the same, because the source rosdistro will be leveraging the snapshot.
 
 
 Bootstrapping the rolling release

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -40,7 +40,7 @@ To make a new rosdistro, target, from an existing rosdistro, source, an automate
 A snaphot of the source distro will be captured, most likely a git commit-ish.
 The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.
 The tool will then iterate through all repositories in the snapshot of the source rosdistro and attempt to automatically run bloom release on the package at the specific version in the snapshot.
-If it fails the maintainer will be needed to resolve any issues.
+If it fails, the package maintainer will be needed to resolve any issues.
 
 If the process gets interrupted the migration tool can be rerun with the same source snapshot and target rosdistro.
 The migration tool will skip any package already in the target rosdistro.

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -44,7 +44,7 @@ If it fails, the package maintainer will be needed to resolve any issues.
 
 If the process gets interrupted the migration tool can be rerun with the same source snapshot and target rosdistro.
 The migration tool will skip any package already in the target rosdistro.
-The rerun is valuable in cases when a maintainer has resolved an an issue and many more downstream repositories are unblocked, as well as if the operation gets interrupted.
+The rerun is valuable in cases when a maintainer has resolved an issue and many more downstream repositories are unblocked, as well as if the operation gets interrupted.
 
 After the snapshot is taken maintainers must make releases for both the source rosdistro and target rosdistro as develoment is considered forked.
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -82,11 +82,17 @@ Recommendations for package maintainers
 Versioning between rolling and stable distributions
 ---------------------------------------------------
 
-When a new stable release is created, the ROS core team strongly recommends that the next release made into the rolling release bump at least the minor version number.
-For example if the version of a package in both the rolling and current stable distribution is ``1.2.3`` and there are new changes that are targeting the rolling distribution only, bump the version to at least ``1.3.0``.
-This allows the patch release of the ``1.2.x`` series to be used for any future changes targeting only the stable distribution.
-Even if no changes are planned it is still a good idea to leave room for unanticipated fixes.
-The alternative is that version numbers may get confusing as the rolling distribution contains ``1.2.4`` but ``1.2.5`` is released only into the stable distribution as a fix on ``1.2.3``.
+When releasing changes compatible with both the stable and the rolling distributions, it's recommended to release the change into both the stable and rolling release keeping the same version number.
+If the stable and rolling distribtions have already diverged, it's recommended to backport just the compatible change to the stable distribution and include it in a new patch release.
+
+When releasing changes that are not compatible with the stable distribution, it's recommended to bump the major or minor version number rather than just the patch version number.
+This allows future patch releases in the stable distribution to be made without re-using or interleaving version numbers between distributions.
+
+For example if the version of a package in both the rolling and current stable distribution is ``1.2.3``:
+
+- A bug fix that is compatible with the stable distribution can be released as ``1.2.4`` into both the stable and rolling distributions.
+- A feature that is not available or compatible with the stable distribution can be released as ``1.3.0`` into the rolling distribution.
+- A bug fix that affects both the stable and rolling distributions can be released into the rolling distribution as ``1.3.1`` and then backported to the ``1.2`` release channel as ``1.2.5``.
 
 
 Implementation

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -82,15 +82,6 @@ A new distribution_status semantic value of ``rolling`` will be added to the ros
 Rolling releases will be excluded from consideration in certain status pages (such as the blocked_releases_* pages) and considered differently from the active stable distributions.
 
 
-Additions to ros_buildfarm and bloom
-------------------------------------
-
-The ros_buildfarm [2]_ and bloom [3]_ projects will both require changes to allow bloom to be run on a ROS build farm.
-ros_buildfarm will require additional jobs that can re-run bloom unattended when the rolling release platforms change, or when dependencies that were previously unavailable have been made available.
-
-Bloom may require some changes to allow it to be run unattended with pre-selected answers to interactive questions.
-
-
 Managing build farm-writable release repositories
 -------------------------------------------------
 

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -35,7 +35,7 @@ Release process
 Automated release migration tool
 --------------------------------
 
-To make a new rosdistro, target, from an existing rosdistro, source. An automated migration tool is available to to avoid manual labor.
+To make a new rosdistro, target, from an existing rosdistro, source. An automated migration tool is available to to reduce manual labor.
 
 A snaphot of the source distro will be captured, most likely a git commit-ish.
 The release manager should then setup the target rosdistro with all the appropriate configurations, such as target platforms and architectures.

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -1,0 +1,130 @@
+REP: 2002
+Title: ROS 2 Rolling Release
+Author: Steven! Ragnarok <steven@openrobotics.org>
+Status: Draft
+Type: Informational
+Content-Type: text/x-rst
+Created: 05-Sep-2019
+Post-History: 05-Sep-2019, 03-Oct-2019
+
+
+Abstract
+========
+
+This REP describes a rolling ROS 2 distribution which will serve as the target for ongoing development of ROS 2.
+It also describes how future releases of ROS 2 may be produced by taking a snapshot of the rolling distribution to produce the next fixed release of ROS 2. 
+
+
+Motivation
+==========
+
+In order to reduce the workload of Open Robotics staff and individual package maintainers when bootstrapping new ROS releases a rolling ROS distribution will be created to serve as the foundation for subsequent stable ROS distributions.
+
+
+Support status
+==============
+
+The rolling release itself will not be considered a supported platform.
+Distribution syncs will be performed on a regular cadence just like stable distributions but regressions may not block a rolling release sync.
+During the pre-release phase for stable ROS distributions releases in the rolling distribution may be blocked or held back in order to conform to the support requirements of the upcoming stable release.
+
+
+Release process
+===============
+
+Releasing stable ROS distributions from a rolling release
+---------------------------------------------------------
+
+When a new stable release is being prepared, the rolling release will be used as a staging ground to prepare that release.
+Updates and new package releases made to the rolling release will be propagated automatically to the stable release.
+At an announced time prior to the official stable release, the stable distribution will be created and packages with successful builds on the rolling release will be automatically released via bloom into the stable release.
+Once the stable distribution has been created and the automatic bloom process has been run, changes to the rolling release may not be automatically propagated to the stable release although 
+
+
+Updating the rolling release platforms
+--------------------------------------
+
+The rolling release is intended to remain availabe indefinitely and so will not be retired or reach end-of-support status without an update to this REP and the ROS distribution release process.
+However, this does mean that platform changes during the life of the rolling distribution are going to occur and the rolling release may target platforms that are themselves unstable or in a pre-release state.
+When a platform change is coming, the intended date of change will be announced ahead of time.
+Once the platforms have been updated, everything currently in the rolling release will be automatically re-released via bloom to target the updated release platforms.
+
+
+Bootstrapping the rolling release
+---------------------------------
+
+The first release of the rolling rosdistro will use the same procedure we've used for all stable rosdistros previously.
+Packages will be released via bloom into an empty distribution until the distribution is relatively complete.
+Package maintainers may then choose to make releases into the rolling rosdistro.
+
+
+Recommendations for package maintainers
+=======================================
+
+Versioning between rolling and stable distributions
+---------------------------------------------------
+
+When a new stable release is created, the ROS core team strongly recommends that the next release made into the rolling release bump at least the minor version number.
+For example if the version of a package in both the rolling and current stable distribution is ``1.2.3`` and there are new changes that are targeting the rolling distribution only, bump the version to at least ``1.3.0``.
+This allows the patch release of the ``1.2.x`` series to be used for any future changes targeting only the stable distribution.
+Even if no changes are planned it is still a good idea to leave room for unanticipated fixes.
+The alternative is that version numbers may get confusing as the rolling distribution contains ``1.2.4`` but ``1.2.5`` is released only into the stable distribution as a fix on ``1.2.3``.
+
+
+Implementation
+==============
+
+
+Changes to rosdistro distribution files
+---------------------------------------
+
+A new distribution_status semantic value of ``rolling`` will be added to the rosdistro index v4 format specified in REP-153 [1]_.
+Rolling releases will be excluded from consideration in certain status pages (such as the blocked_releases_* pages) and considered differently from the active stable distributions.
+
+
+Additions to ros_buildfarm and bloom
+------------------------------------
+
+The ros_buildfarm [2]_ and bloom [3]_ projects will both require changes to allow bloom to be run on a ROS build farm.
+ros_buildfarm will require additional jobs that can re-run bloom unattended when the rolling release platforms change, or when dependencies that were previously unavailable have been made available.
+
+Bloom may require some changes to allow it to be run unattended with pre-selected answers to interactive questions.
+
+
+Managing build farm writable release repositories
+-------------------------------------------------
+
+In order to allow bloom to be run in an automated fashion the release repository must be writeable by the build farm agents.
+Release repositories may be hosted in a standard location such as the ros-gbp or ros2-gbp organizations on GitHub.
+If a repository isn't writeable by the build farm the release repository may be forked to a standard location for the purpose of making the release.
+Some form of breadcrumb will be left so that the previous release repository is noted.
+
+
+
+References
+==========
+
+.. [1] REP 153: ROS distribution files
+   (http://www.ros.org/reps/rep-0153.html)
+
+.. [2] ros_buildfarm repository
+   (https://github.com/ros-infrastructure/ros_buildfarm)
+
+.. [3] bloom repository
+   (https://github.com/ros-infrastructure/bloom)
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/rep-2002.rst
+++ b/rep-2002.rst
@@ -66,7 +66,7 @@ However, this does mean that platform changes during the life of the rolling dis
 When a platform change is coming, the intended date of change will be announced ahead of time.
 
 The platform change is a unique invocation of the migration tool where the source and target rosdistro will be the same.
-To do this the person managing the migration will take the snapshot of the source rosdistro and then clear it's contents as well as updating the targetget platforms.
+To do this the person managing the migration will take the snapshot of the source rosdistro and then clear it's contents as well as updating the target platforms.
 After which the migration tool can be invoked with the target and source rosdistro as the same, because the source rosdistro will be leveraging the snapshot.
 
 


### PR DESCRIPTION
This is a proposal for a rolling ROS distribution that will make future ROS 2 releases easier to bootstrap.

:scroll: [Rendered rst via GitHub](https://github.com/nuclearsandwich/rep/blob/rep-2002/rep-2002.rst)