### PR TITLE
REP 154: extend distribution files to support the test_abi option

### DIFF
--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -49,7 +49,8 @@ packages can cover at least two scenarios:
    scripts.
 
 The original target to compare both use cases and to be taken as the stable
-API/ABI are the latest stable released packages.
+API/ABI are the latest stable released packages for each ROS distribution
+under testing.
 
 Specification
 =============

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -19,10 +19,10 @@ The intention is to annotate a ROS distribution with more information,
 particularly with the option of running an ABI/API analysis for pull requests
 and devel jobs.
 
-This REP is an extension to the file format originally defined in REP 143[1]_
-and extended in REP 153[2]_.
-It currently does not repeat the content of REPs 143 and 153 but only states
-the differences.
+This REP is an extension to the file format originally defined in REP 137[1]_
+and extended in REPS: 141[2]_, 143[3]_ and 153[4]_.
+It currently does not repeat the content of these REPs but only states the
+differences.
 
 
 Motivation
@@ -34,7 +34,7 @@ ROS packages.
 Two aspects of the stability are the respect of the current API and, extending
 this first one, the stability of the ABI.
 
-Traditionally the ROS policy related to releases[3]_ does not impose any
+Traditionally the ROS policy related to releases[4]_ does not impose any
 restriction to changes in the application or binary interface of the
 ROS packages.
 This lack of restriction applies to changes inside the same ROS distribution or
@@ -46,7 +46,7 @@ packages can cover at least two scenarios:
 1. Run an API/ABI analysis together with changes coming from
    pull requests.
    Currently the option to use CI in the pull request is covered by the
-   `test_pull_requests` (as described in REP 143[1]_)
+   `test_pull_requests` (as described in REP 143[3]_)
 
 1. Run an API/ABI analysis of changes that appear in the source code
    of ROS packages.
@@ -76,7 +76,7 @@ Reference implementation
 ------------------------
 This REP is to be implemented in version 0.7.6 of the Python package *rosdistro*.
 It will serve as a reference implementation for this REP.
-A draft implementation can be found in [4]_.
+A draft implementation can be found in [6]_.
 
 
 Compatibility considerations
@@ -98,10 +98,12 @@ Only the buildfarm code and rosdistro need to be updated.
 
 References
 ==========
-.. [1] REP 153: http://www.ros.org/reps/rep-0153.html
-.. [2] REP 143: http://www.ros.org/reps/rep-0143.html
-.. [3] ROS Release Policy http://wiki.ros.org/Distributions/ReleasePolicy
-.. [4] Patch to python-rosdistro:
+.. [1] REP 137: http://www.ros.org/reps/rep-0137.html
+.. [2] REP 141: http://www.ros.org/reps/rep-0141.html
+.. [3] REP 143: http://www.ros.org/reps/rep-0143.html
+.. [4] REP 153: http://www.ros.org/reps/rep-0153.html
+.. [5] ROS Release Policy http://wiki.ros.org/Distributions/ReleasePolicy
+.. [6] Patch to python-rosdistro:
   https://github.com/ros-infrastructure/rosdistro/pull/TODO
 
 

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -66,7 +66,7 @@ Distribution file
 
   * source
 
-    * test_abi: an optional boolean (default false) to run an API/ABI analsys
+    * test_abi: an optional boolean (default false) to run an API/ABI analysis
       of the code in the pull request against the latest released packages in
       devel jobs.
       If ``test_pull_requests`` is enabled, run the analysis as part of the CI

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -28,17 +28,14 @@ differences.
 Motivation
 ==========
 
-Since the creation of ROS1 some developers and users have been looking into
-improving the stability of the different updates that reach the set of
-ROS packages.
-Two aspects of the stability are the respect of the current API and, extending
-this first one, the stability of the ABI.
+The stability of the different ROS distributions with respect to API/ABI stability
+has been part of the work done by ROS maintainers.
+Until now the changes are manually reviewed and their impact on the API or ABI is
+being judged by the reviewer with no automated tool that assist with this task.
 
-Traditionally the ROS policy related to releases[4]_ does not impose any
-restriction to changes in the application or binary interface of the
-ROS packages.
-This lack of restriction applies to changes inside the same ROS distribution or
-changes between different ROS distributions.
+The motivation of this REP is to ensure that undesired changes in terms of
+source/binary stability are caught in the review process and maintainers can
+make decisions with more information about the effects of changes.
 
 The inclusion of an option for testing the ABI/API changes in ROS
 packages can cover at least two scenarios:
@@ -76,7 +73,7 @@ Reference implementation
 ------------------------
 This REP is to be implemented in version 0.7.6 of the Python package *rosdistro*.
 It will serve as a reference implementation for this REP.
-A draft implementation can be found in [6]_.
+A draft implementation can be found in [5]_.
 
 
 Compatibility considerations
@@ -102,8 +99,7 @@ References
 .. [2] REP 141: http://www.ros.org/reps/rep-0141.html
 .. [3] REP 143: http://www.ros.org/reps/rep-0143.html
 .. [4] REP 153: http://www.ros.org/reps/rep-0153.html
-.. [5] ROS Release Policy http://wiki.ros.org/Distributions/ReleasePolicy
-.. [6] Patch to python-rosdistro:
+.. [5] Patch to python-rosdistro:
   https://github.com/ros-infrastructure/rosdistro/pull/TODO
 
 

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -1,7 +1,7 @@
 REP: 154
 Title: test_abi support for ROS distribution files
 Author: Jose Luis Rivero <jrivero@openrobotics.org>
-Status: Final
+Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 21-Nov-2018

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -20,8 +20,8 @@ particularly with the option of running an ABI/API analysis for pull requests
 and devel jobs.
 
 This REP is an extension to the file format originally defined in REP 143[1]_
-and extended in REP 153[2]_. It currently does not repeat the content of REP
-143 but only states the differences.
+and extended in REP 153[2]_. It currently does not repeat the content of REPs
+143 and 153 but only states the differences.
 
 
 Motivation

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -20,8 +20,9 @@ particularly with the option of running an ABI/API analysis for pull requests
 and devel jobs.
 
 This REP is an extension to the file format originally defined in REP 143[1]_
-and extended in REP 153[2]_. It currently does not repeat the content of REPs
-143 and 153 but only states the differences.
+and extended in REP 153[2]_.
+It currently does not repeat the content of REPs 143 and 153 but only states
+the differences.
 
 
 Motivation
@@ -29,24 +30,27 @@ Motivation
 
 Since the creation of ROS1 some developers and users have been looking into
 improving the stability of the different updates that reach the set of
-ROS packages. Two aspects of the stability are the respect of the current
-API and, extending this first one, the stability of the ABI.
+ROS packages.
+Two aspects of the stability are the respect of the current API and, extending
+this first one, the stability of the ABI.
 
 Traditionally the ROS policy related to releases[3]_ does not impose any
 restriction to changes in the application or binary interface of the
-ROS packages. This lack of restriction applies to changes inside the
-same ROS distribution or changes between different ROS distributions.
+ROS packages.
+This lack of restriction applies to changes inside the same ROS distribution or
+changes between different ROS distributions.
 
 The inclusion of an option for testing the ABI/API changes in ROS
 packages can cover at least two scenarios:
 
 1. Run an API/ABI analysis together with changes coming from
-   pull requests. Currently the option to use CI in the pull request
-   is covered by the `test_pull_requests` (as described in REP 143[1]_)
+   pull requests.
+   Currently the option to use CI in the pull request is covered by the
+   `test_pull_requests` (as described in REP 143[1]_)
 
 1. Run an API/ABI analysis of changes that appear in the source code
-   of ROS packages. This would be part of the CI cycle present in the devel
-   scripts.
+   of ROS packages.
+   This would be part of the CI cycle present in the devel scripts.
 
 The original target to compare both use cases and to be taken as the stable
 API/ABI are the latest stable released packages for each ROS distribution
@@ -64,8 +68,9 @@ Distribution file
 
     * test_abi: an optional boolean (default false) to run an API/ABI analsys
       of the code in the pull request against the latest released packages in
-      devel jobs. If ``test_pull_requests`` is enabled, run the analysis as
-      part of the CI integrated in pull requests.
+      devel jobs.
+      If ``test_pull_requests`` is enabled, run the analysis as part of the CI
+      integrated in pull requests.
 
 Reference implementation
 ------------------------
@@ -78,8 +83,9 @@ Compatibility considerations
 ============================
 
 Given the nature of being an optional flag added, the default behaviour should
-be not to change the current actions in devel or pull requests scripts. That
-is the goal of defaulting the option to false in the absence of this option.
+be not to change the current actions in devel or pull requests scripts.
+That is the goal of defaulting the option to false in the absence of this
+option.
 This way current configurations are perfectly valid and unless a proactive
 action is done by ROS Package maintainers or ROS admins nothing new
 should happen in the CI scripts.

--- a/rep-0154.rst
+++ b/rep-0154.rst
@@ -1,0 +1,103 @@
+REP: 154
+Title: test_abi support for ROS distribution files
+Author: Jose Luis Rivero <jrivero@openrobotics.org>
+Status: Final
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 21-Nov-2018
+Post-History: 21-Nov-2019
+
+
+.. contents::
+
+Abstract
+========
+This REP updates the specification of the ROS distribution files facilitated in
+the building, packaging, testing and documenting process.
+
+The intention is to annotate a ROS distribution with more information,
+particularly with the option of running an ABI/API analysis for pull requests
+and devel jobs.
+
+This REP is an extension to the file format originally defined in REP 143[1]_
+and extended in REP 153[2]_. It currently does not repeat the content of REP
+143 but only states the differences.
+
+
+Motivation
+==========
+
+Since the creation of ROS1 some developers and users has been looking into
+improving the stability of the different updates that reach the set of
+ROS packages. Two aspects of the stability are the respect of the current
+API and, extending this first one, the stability of the ABI.
+
+Traditionally the ROS policy related to releases[3]_ does not impose any
+restriction to changes in the application or binary interface of the
+ROS packages. This lack of restriction applies to: changes inside the
+same ROS distribution or changes between different ROS distributions.
+
+The inclusion of an option for testing the ABI/API changes in ROS
+packages can cover at least two scenarios:
+
+1. Run an API/ABI analysis together with changes coming from
+   pull requests. Currently the option to use CI in the pull request
+   is covered by the `test_pull_requests` (as described in REP 143[1]_)
+
+1. Run an API/ABI analysis of changes that appear in the source code
+   of ROS packages. This would be part of the CI cycle present  in the devel
+   scripts.
+
+The original target to compare both use cases and to be taken as the stable
+API/ABI are the latest stable released packages.
+
+Specification
+=============
+
+Distribution file
+-----------------
+
+* repositories
+
+  * source
+
+    * test_abi: an optional boolean (default false) to run an API/ABI analsys
+      of the code in the pull request against the latest released packages in
+      devel jobs. If ``test_pull_requests`` is enabled, run the analysis as
+      part of the CI integrated in pull requests.
+
+Reference implementation
+------------------------
+This REP is to be implemented in version 0.7.6 of the Python package *rosdistro*.
+It will serve as a reference implementation for this REP.
+A draft implementation can be found in [4]_.
+
+
+Compatibility considerations
+============================
+
+Given the nature of being an optional flag added, the default behaviour should
+be not to change the current actions in devel or pull requests scripts. That
+is the goal of defaulting the option to false in the absence of this option.
+This way current configurations are perfectly valid and unless a proactive
+action is done by ROS Package maintainers or ROS admins nothing new
+should happen in the CI scripts.
+
+
+Affected tools
+-----
+
+Only the buildfarm code and rosdistro need to be updated.
+
+References
+==========
+.. [1] REP 153: http://www.ros.org/reps/rep-0153.html
+.. [2] REP 143: http://www.ros.org/reps/rep-0143.html
+.. [3] ROS Release Policy http://wiki.ros.org/Distributions/ReleasePolicy
+.. [4] Patch to python-rosdistro:
+  https://github.com/ros-infrastructure/rosdistro/pull/TODO
+
+
+Copyright
+=========
+This document has been placed in the public domain.


### PR DESCRIPTION
This REP extend the work done in REP153 (and previous) to include an option named `test_abi` to perform an ABI/API checking on buildfarm CI. Default is false. Implementation details at ros-infrastructure/ros_buildfarm#681.

Rework of pull #213 
