### PR TITLE
REP 142: Add actionlib_tools to the desktop metapackage

### DIFF
--- a/rep-0142.rst
+++ b/rep-0142.rst
@@ -144,8 +144,8 @@ Both of these variants contain tutorials for the stacks they provide.
 
   - desktop:
       extends: [robot, viz]
-      packages: [angles, common_tutorials, geometry_tutorials, ros_tutorials,
-                 roslint, visualization_tutorials]
+      packages: [actionlib_tools, angles, common_tutorials, geometry_tutorials,
+                 ros_tutorials, roslint, visualization_tutorials]
 
   - desktop_full:
       extends: [desktop, perception, simulators]


### PR DESCRIPTION
See ros/metapackages#29

Update REP 142 to include actionlib_tools in the desktop metapackage from Indigo through Kinetic.

This PR corresponds to ros/metapackages#29 being cherry-picked back to Indigo through Kinetic.

(Similar: #220 makes the same changes for REP 150)