### PR TITLE
REP 2005: ROS 2 Common Packages

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -143,11 +143,11 @@ All items on the list for the next distro should already be released into the ro
   * `ament_lint/ament_uncrustify <https://index.ros.org/p/ament_uncrustify/>`_
   * `ament_lint/ament_xmllint <https://index.ros.org/p/ament_xmllint/>`_
   * `ros_environment/ros_environment <https://index.ros.org/p/ros_environment/>`_
-  * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_ **(UNMATCHED)**
-  * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_ **(UNMATCHED)**
-  * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_ **(UNMATCHED)**
-  * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_ **(UNMATCHED)**
-  * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_ **(UNMATCHED)**
+  * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_ *(not a ROS package)*
+  * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_ *(not a ROS package)*
+  * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_ *(not a ROS package)*
+  * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_ *(not a ROS package)*
+  * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_ *(not a ROS package)*
   * `ament_cmake_ros/ament_cmake_ros <https://index.ros.org/p/ament_cmake_ros/>`_
   * `ament_cmake_ros/domain_coordinator <https://index.ros.org/p/domain_coordinator/>`_
 
@@ -319,36 +319,70 @@ All items on the list for the next distro should already be released into the ro
     * `laser_proc/laser_proc <https://index.ros.org/p/laser_proc/>`_
     * `depthimage_to_laserscan/depthimage_to_laserscan <https://index.ros.org/p/depthimage_to_laserscan/>`_
 
-  * `navigation2/costmap_queue <https://index.ros.org/p/costmap_queue/>`_
-  * `navigation2/dwb_core <https://index.ros.org/p/dwb_core/>`_
-  * `navigation2/dwb_critics <https://index.ros.org/p/dwb_critics/>`_
-  * `navigation2/dwb_msgs <https://index.ros.org/p/dwb_msgs/>`_
-  * `navigation2/dwb_plugins <https://index.ros.org/p/dwb_plugins/>`_
-  * `navigation2/nav2_amcl <https://index.ros.org/p/nav2_amcl/>`_
-  * `navigation2/nav2_behavior_tree <https://index.ros.org/p/nav2_behavior_tree/>`_
-  * `navigation2/nav2_bringup <https://index.ros.org/p/nav2_bringup/>`_
-  * `navigation2/nav2_bt_navigator <https://index.ros.org/p/nav2_bt_navigator/>`_
-  * `navigation2/nav2_common <https://index.ros.org/p/nav2_common/>`_
-  * `navigation2/nav2_controller <https://index.ros.org/p/nav2_controller/>`_
-  * `navigation2/nav2_core <https://index.ros.org/p/nav2_core/>`_
-  * `navigation2/nav2_costmap_2d <https://index.ros.org/p/nav2_costmap_2d/>`_
-  * `navigation2/nav2_dwb_controller <https://index.ros.org/p/nav2_dwb_controller/>`_
-  * `navigation2/nav2_gazebo_spawner <https://index.ros.org/p/nav2_gazebo_spawner/>`_
-  * `navigation2/nav2_lifecycle_manager <https://index.ros.org/p/nav2_lifecycle_manager/>`_
-  * `navigation2/nav2_map_server <https://index.ros.org/p/nav2_map_server/>`_
-  * `navigation2/nav2_msgs <https://index.ros.org/p/nav2_msgs/>`_
-  * `navigation2/nav2_navfn_planner <https://index.ros.org/p/nav2_navfn_planner/>`_
-  * `navigation2/nav2_planner <https://index.ros.org/p/nav2_planner/>`_
-  * `navigation2/nav2_recoveries <https://index.ros.org/p/nav2_recoveries/>`_
-  * `navigation2/nav2_rviz_plugins <https://index.ros.org/p/nav2_rviz_plugins/>`_
-  * `navigation2/nav2_system_tests <https://index.ros.org/p/nav2_system_tests/>`_
-  * `navigation2/nav2_util <https://index.ros.org/p/nav2_util/>`_
-  * `navigation2/nav2_voxel_grid <https://index.ros.org/p/nav2_voxel_grid/>`_
-  * `navigation2/nav2_waypoint_follower <https://index.ros.org/p/nav2_waypoint_follower/>`_
-  * `navigation2/nav_2d_msgs <https://index.ros.org/p/nav_2d_msgs/>`_
-  * `navigation2/nav_2d_utils <https://index.ros.org/p/nav_2d_utils/>`_
-  * `navigation2/navigation2 <https://index.ros.org/p/navigation2/>`_
-  * `ros-planning/moveit2 <https://github.com/ros-planning/moveit2>`_ **(UNMATCHED)**
+  * Navigation2
+
+    * `navigation2/costmap_queue <https://index.ros.org/p/costmap_queue/>`_
+    * `navigation2/dwb_core <https://index.ros.org/p/dwb_core/>`_
+    * `navigation2/dwb_critics <https://index.ros.org/p/dwb_critics/>`_
+    * `navigation2/dwb_msgs <https://index.ros.org/p/dwb_msgs/>`_
+    * `navigation2/dwb_plugins <https://index.ros.org/p/dwb_plugins/>`_
+    * `navigation2/nav2_amcl <https://index.ros.org/p/nav2_amcl/>`_
+    * `navigation2/nav2_behavior_tree <https://index.ros.org/p/nav2_behavior_tree/>`_
+    * `navigation2/nav2_bringup <https://index.ros.org/p/nav2_bringup/>`_
+    * `navigation2/nav2_bt_navigator <https://index.ros.org/p/nav2_bt_navigator/>`_
+    * `navigation2/nav2_common <https://index.ros.org/p/nav2_common/>`_
+    * `navigation2/nav2_controller <https://index.ros.org/p/nav2_controller/>`_
+    * `navigation2/nav2_core <https://index.ros.org/p/nav2_core/>`_
+    * `navigation2/nav2_costmap_2d <https://index.ros.org/p/nav2_costmap_2d/>`_
+    * `navigation2/nav2_dwb_controller <https://index.ros.org/p/nav2_dwb_controller/>`_
+    * `navigation2/nav2_gazebo_spawner <https://index.ros.org/p/nav2_gazebo_spawner/>`_
+    * `navigation2/nav2_lifecycle_manager <https://index.ros.org/p/nav2_lifecycle_manager/>`_
+    * `navigation2/nav2_map_server <https://index.ros.org/p/nav2_map_server/>`_
+    * `navigation2/nav2_msgs <https://index.ros.org/p/nav2_msgs/>`_
+    * `navigation2/nav2_navfn_planner <https://index.ros.org/p/nav2_navfn_planner/>`_
+    * `navigation2/nav2_planner <https://index.ros.org/p/nav2_planner/>`_
+    * `navigation2/nav2_recoveries <https://index.ros.org/p/nav2_recoveries/>`_
+    * `navigation2/nav2_rviz_plugins <https://index.ros.org/p/nav2_rviz_plugins/>`_
+    * `navigation2/nav2_system_tests <https://index.ros.org/p/nav2_system_tests/>`_
+    * `navigation2/nav2_util <https://index.ros.org/p/nav2_util/>`_
+    * `navigation2/nav2_voxel_grid <https://index.ros.org/p/nav2_voxel_grid/>`_
+    * `navigation2/nav2_waypoint_follower <https://index.ros.org/p/nav2_waypoint_follower/>`_
+    * `navigation2/nav_2d_msgs <https://index.ros.org/p/nav_2d_msgs/>`_
+    * `navigation2/nav_2d_utils <https://index.ros.org/p/nav_2d_utils/>`_
+    * `navigation2/navigation2 <https://index.ros.org/p/navigation2/>`_
+
+  * MoveIt2
+
+    * `moveit2/moveit_jog_arm <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_setup_assistant <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/run_moveit_cpp <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_core <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_occupancy_map_monitor <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_robot_interaction <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_warehouse <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_manipulation <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_move_group <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_planning <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_perception <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_visualization <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_benchmarks <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_planning_interface <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_fake_controller_manager <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_simple_controller_manager <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_plugins <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_ros_control_interface <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_planners_ompl <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_planners_trajopt <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_planners <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_chomp_optimizer_adapter <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/chomp_motion_planner <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_planners_chomp <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_commander <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_runtime <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/moveit_kinematics <https://github.com/ros-planning/moveit2/>`_
+
   * `interactive_markers/interactive_markers <https://index.ros.org/p/interactive_markers/>`_
   * `geometry2/examples_tf2_py <https://index.ros.org/p/examples_tf2_py/>`_
   * `geometry2/geometry2 <https://index.ros.org/p/geometry2/>`_
@@ -367,8 +401,8 @@ All items on the list for the next distro should already be released into the ro
   * `sros2/sros2 <https://index.ros.org/p/sros2/>`_
   * `sros2/sros2_cmake <https://index.ros.org/p/sros2_cmake/>`_
   * `teleop_twist_joy/teleop_twist_joy <https://index.ros.org/p/teleop_twist_joy/>`_
-  * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_ **(UNMATCHED)**
-  * `ubuntu-robotics/nodl <https://github.com/ubuntu-robotics/nodl>`_ **(UNMATCHED)**
+  * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_
+  * `ubuntu-robotics/nodl_python <https://github.com/ubuntu-robotics/nodl>`_
   * ROS Drivers
 
     * `joystick_drivers/joy <https://index.ros.org/p/joy/>`_
@@ -394,7 +428,7 @@ All items on the list for the next distro should already be released into the ro
     * `phidgets_drivers/phidgets_msgs <https://index.ros.org/p/phidgets_msgs/>`_
     * `phidgets_drivers/phidgets_spatial <https://index.ros.org/p/phidgets_spatial/>`_
     * `phidgets_drivers/phidgets_temperature <https://index.ros.org/p/phidgets_temperature/>`_
-    * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_ **(UNMATCHED)**
+    * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
 
 * Documentation, Examples, Tutorials
 
@@ -417,7 +451,7 @@ All items on the list for the next distro should already be released into the ro
   * `demos/quality_of_service_demo_cpp <https://index.ros.org/p/quality_of_service_demo_cpp/>`_
   * `demos/quality_of_service_demo_py <https://index.ros.org/p/quality_of_service_demo_py/>`_
   * `demos/topic_monitor <https://index.ros.org/p/topic_monitor/>`_
-  * `ros2/design <https://github.com/ros2/design>`_ **(UNMATCHED)**
+  * `ros2/design <https://github.com/ros2/design>`_ *(not a ROS package)*
   * `examples/examples_rclcpp_minimal_action_client <https://index.ros.org/p/examples_rclcpp_minimal_action_client/>`_
   * `examples/examples_rclcpp_minimal_action_server <https://index.ros.org/p/examples_rclcpp_minimal_action_server/>`_
   * `examples/examples_rclcpp_minimal_client <https://index.ros.org/p/examples_rclcpp_minimal_client/>`_
@@ -434,8 +468,8 @@ All items on the list for the next distro should already be released into the ro
   * `examples/examples_rclpy_minimal_publisher <https://index.ros.org/p/examples_rclpy_minimal_publisher/>`_
   * `examples/examples_rclpy_minimal_service <https://index.ros.org/p/examples_rclpy_minimal_service/>`_
   * `examples/examples_rclpy_minimal_subscriber <https://index.ros.org/p/examples_rclpy_minimal_subscriber/>`_
-  * `ros2/ros_core_documentation <https://github.com/ros2/ros_core_documentation>`_ **(UNMATCHED)**
-  * `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`_ **(UNMATCHED)**
+  * `ros2/ros_core_documentation <https://github.com/ros2/ros_core_documentation>`_ *(not a ROS package)*
+  * `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`_ *(not a ROS package)*
 
 * Robot
 
@@ -484,8 +518,10 @@ All items on the list for the next distro should already be released into the ro
   * `rviz/rviz_rendering_tests <https://index.ros.org/p/rviz_rendering_tests/>`_
   * `rviz/rviz_visual_testing_framework <https://index.ros.org/p/rviz_visual_testing_framework/>`_
   * `cross_compile/cross_compile <https://github.com/ros-tooling/cross_compile>`_
-  * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_ **(UNMATCHED)**
-  * `ApexAI/performance_test <https://gitlab.com/ApexAI/performance_test>`_ **(UNMATCHED)**
+  * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_
+  * `ApexAI/performance_test <https://gitlab.com/ApexAI/performance_test>`_
+  * `ApexAI/performance_test_ros1_msgs <https://gitlab.com/ApexAI/performance_test>`_
+  * `ApexAI/performance_test_ros1_publisher <https://gitlab.com/ApexAI/performance_test>`_
   * RQt
 
     * `python_qt_binding/python_qt_binding <https://index.ros.org/p/python_qt_binding/>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -170,6 +170,8 @@ Content
   * `ros2/message_filters <https://github.com/ros2/message_filters>`_
   * `ros2/sros2 <https://github.com/ros2/sros2>`_
   * `ros2/teleop_twist_joy <https://github.com/ros2/teleop_twist_joy>`_
+  * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_
+  * `ubuntu-robotics/nodl <https://github.com/ubuntu-robotics/nodl>`_
   * ROS Drivers
 
     * `ros2/joystick_drivers <https://github.com/ros2/joystick_drivers>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -86,182 +86,434 @@ The common packages may vary among distros; unless otherwise annotated below, ea
 When planning starts for a new distro, the package list from the previous distro will be copied in as a starting point.
 All items on the list for the next distro should already be released into the rolling distro; as a bootstrapping exception, items on the list for Foxy may take some time to be released.
 
-**TODO: expand the repositories below to individual packages**
-
 * Buildsystem, package index and tooling around
 
-  * `ament/ament_cmake <https://github.com/ament/ament_cmake>`_
-  * `ament/ament_index <https://github.com/ament/ament_index>`_
-  * `ament/ament_package <https://github.com/ament/ament_package>`_
-  * `ament/ament_lint <https://github.com/ament/ament_lint>`_
-  * `ros/ros_environment <https://github.com/ros/ros_environment>`_
-  * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_
-  * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_
-  * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_
-  * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_
-  * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_
-  * `ros2/ament_cmake_ros <https://github.com/ros2/ament_cmake_ros>`_
+  * `ament_cmake/ament_cmake <https://index.ros.org/p/ament_cmake/>`_
+  * `ament_cmake/ament_cmake_auto <https://index.ros.org/p/ament_cmake_auto/>`_
+  * `ament_cmake/ament_cmake_core <https://index.ros.org/p/ament_cmake_core/>`_
+  * `ament_cmake/ament_cmake_export_definitions <https://index.ros.org/p/ament_cmake_export_definitions/>`_
+  * `ament_cmake/ament_cmake_export_dependencies <https://index.ros.org/p/ament_cmake_export_dependencies/>`_
+  * `ament_cmake/ament_cmake_export_include_directories <https://index.ros.org/p/ament_cmake_export_include_directories/>`_
+  * `ament_cmake/ament_cmake_export_interfaces <https://index.ros.org/p/ament_cmake_export_interfaces/>`_
+  * `ament_cmake/ament_cmake_export_libraries <https://index.ros.org/p/ament_cmake_export_libraries/>`_
+  * `ament_cmake/ament_cmake_export_link_flags <https://index.ros.org/p/ament_cmake_export_link_flags/>`_
+  * `ament_cmake/ament_cmake_export_targets <https://github.com/ament/ament_cmake>`_
+  * `ament_cmake/ament_cmake_gmock <https://index.ros.org/p/ament_cmake_gmock/>`_
+  * `ament_cmake/ament_cmake_gtest <https://index.ros.org/p/ament_cmake_gtest/>`_
+  * `ament_cmake/ament_cmake_include_directories <https://index.ros.org/p/ament_cmake_include_directories/>`_
+  * `ament_cmake/ament_cmake_libraries <https://index.ros.org/p/ament_cmake_libraries/>`_
+  * `ament_cmake/ament_cmake_nose <https://index.ros.org/p/ament_cmake_nose/>`_
+  * `ament_cmake/ament_cmake_pytest <https://index.ros.org/p/ament_cmake_pytest/>`_
+  * `ament_cmake/ament_cmake_python <https://index.ros.org/p/ament_cmake_python/>`_
+  * `ament_cmake/ament_cmake_target_dependencies <https://index.ros.org/p/ament_cmake_target_dependencies/>`_
+  * `ament_cmake/ament_cmake_test <https://index.ros.org/p/ament_cmake_test/>`_
+  * `ament_cmake/ament_cmake_version <https://index.ros.org/p/ament_cmake_version/>`_
+  * `ament_index/ament_index_cpp <https://index.ros.org/p/ament_index_cpp/>`_
+  * `ament_index/ament_index_python <https://index.ros.org/p/ament_index_python/>`_
+  * `ament_package/ament_package <https://index.ros.org/p/ament_package/>`_
+  * `ament_lint/ament_clang_format <https://index.ros.org/p/ament_clang_format/>`_
+  * `ament_lint/ament_clang_tidy <https://index.ros.org/p/ament_clang_tidy/>`_
+  * `ament_lint/ament_cmake_clang_format <https://index.ros.org/p/ament_cmake_clang_format/>`_
+  * `ament_lint/ament_cmake_clang_tidy <https://index.ros.org/p/ament_cmake_clang_tidy/>`_
+  * `ament_lint/ament_cmake_copyright <https://index.ros.org/p/ament_cmake_copyright/>`_
+  * `ament_lint/ament_cmake_cppcheck <https://index.ros.org/p/ament_cmake_cppcheck/>`_
+  * `ament_lint/ament_cmake_cpplint <https://index.ros.org/p/ament_cmake_cpplint/>`_
+  * `ament_lint/ament_cmake_flake8 <https://index.ros.org/p/ament_cmake_flake8/>`_
+  * `ament_lint/ament_cmake_lint_cmake <https://index.ros.org/p/ament_cmake_lint_cmake/>`_
+  * `ament_lint/ament_cmake_mypy <https://index.ros.org/p/ament_cmake_mypy/>`_
+  * `ament_lint/ament_cmake_pclint <https://index.ros.org/p/ament_cmake_pclint/>`_
+  * `ament_lint/ament_cmake_pep257 <https://index.ros.org/p/ament_cmake_pep257/>`_
+  * `ament_lint/ament_cmake_pycodestyle <https://github.com/ament/ament_lint>`_
+  * `ament_lint/ament_cmake_pyflakes <https://index.ros.org/p/ament_cmake_pyflakes/>`_
+  * `ament_lint/ament_cmake_uncrustify <https://index.ros.org/p/ament_cmake_uncrustify/>`_
+  * `ament_lint/ament_cmake_xmllint <https://index.ros.org/p/ament_cmake_xmllint/>`_
+  * `ament_lint/ament_copyright <https://index.ros.org/p/ament_copyright/>`_
+  * `ament_lint/ament_cppcheck <https://index.ros.org/p/ament_cppcheck/>`_
+  * `ament_lint/ament_cpplint <https://index.ros.org/p/ament_cpplint/>`_
+  * `ament_lint/ament_flake8 <https://index.ros.org/p/ament_flake8/>`_
+  * `ament_lint/ament_lint <https://index.ros.org/p/ament_lint/>`_
+  * `ament_lint/ament_lint_auto <https://index.ros.org/p/ament_lint_auto/>`_
+  * `ament_lint/ament_lint_cmake <https://index.ros.org/p/ament_lint_cmake/>`_
+  * `ament_lint/ament_lint_common <https://index.ros.org/p/ament_lint_common/>`_
+  * `ament_lint/ament_mypy <https://index.ros.org/p/ament_mypy/>`_
+  * `ament_lint/ament_pclint <https://index.ros.org/p/ament_pclint/>`_
+  * `ament_lint/ament_pep257 <https://index.ros.org/p/ament_pep257/>`_
+  * `ament_lint/ament_pycodestyle <https://github.com/ament/ament_lint>`_
+  * `ament_lint/ament_pyflakes <https://index.ros.org/p/ament_pyflakes/>`_
+  * `ament_lint/ament_uncrustify <https://index.ros.org/p/ament_uncrustify/>`_
+  * `ament_lint/ament_xmllint <https://index.ros.org/p/ament_xmllint/>`_
+  * `ros_environment/ros_environment <https://index.ros.org/p/ros_environment/>`_
+  * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_ **(UNMATCHED)**
+  * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_ **(UNMATCHED)**
+  * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_ **(UNMATCHED)**
+  * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_ **(UNMATCHED)**
+  * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_ **(UNMATCHED)**
+  * `ament_cmake_ros/ament_cmake_ros <https://index.ros.org/p/ament_cmake_ros/>`_
+  * `ament_cmake_ros/domain_coordinator <https://index.ros.org/p/domain_coordinator/>`_
 
 * Third party packages
 
-  * `eProsima/foonathan_memory_vendor <https://github.com/eProsima/foonathan_memory_vendor>`_
-  * `ament/googletest <https://github.com/ament/googletest>`_
-  * `ament/uncrustify_vendor <https://github.com/ament/uncrustify_vendor>`_
-  * `ros2/console_bridge_vendor <https://github.com/ros2/console_bridge_vendor>`_
-  * `ros2/poco_vendor <https://github.com/ros2/poco_vendor>`_
-  * `ros2/spdlog_vendor <https://github.com/ros2/spdlog_vendor>`_
-  * `ros2/tinydir_vendor <https://github.com/ros2/tinydir_vendor>`_
-  * `ros2/tinyxml_vendor <https://github.com/ros2/tinyxml_vendor>`_
-  * `ros2/tinyxml2_vendor <https://github.com/ros2/tinyxml2_vendor>`_
-  * `ros2/yaml_cpp_vendor <https://github.com/ros2/yaml_cpp_vendor>`_
+  * `foonathan_memory_vendor/foonathan_memory_vendor <https://index.ros.org/p/foonathan_memory_vendor/>`_
+  * `googletest/gmock_vendor <https://index.ros.org/p/gmock_vendor/>`_
+  * `googletest/gtest_vendor <https://index.ros.org/p/gtest_vendor/>`_
+  * `uncrustify_vendor/uncrustify_vendor <https://index.ros.org/p/uncrustify_vendor/>`_
+  * `console_bridge_vendor/console_bridge_vendor <https://index.ros.org/p/console_bridge_vendor/>`_
+  * `poco_vendor/poco_vendor <https://index.ros.org/p/poco_vendor/>`_
+  * `spdlog_vendor/spdlog_vendor <https://index.ros.org/p/spdlog_vendor/>`_
+  * `tinydir_vendor/tinydir_vendor <https://index.ros.org/p/tinydir_vendor/>`_
+  * `tinyxml_vendor/tinyxml_vendor <https://index.ros.org/p/tinyxml_vendor/>`_
+  * `tinyxml2_vendor/tinyxml2_vendor <https://index.ros.org/p/tinyxml2_vendor/>`_
+  * `yaml_cpp_vendor/yaml_cpp_vendor <https://index.ros.org/p/yaml_cpp_vendor/>`_
 
 * Utility functionality
 
-  * `micro-ROS/ros_tracing/ros2_tracing <https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing>`_
-  * `osrf/osrf_pycommon <https://github.com/osrf/osrf_pycommon>`_
-  * `osrf/osrf_testing_tools_cpp <https://github.com/osrf/osrf_testing_tools_cpp>`_
-  * `ros/class_loader <https://github.com/ros/class_loader>`_
-  * `ros/pluginlib <https://github.com/ros/pluginlib>`_
-  * `ros2/eigen3_cmake_module <https://github.com/ros2/eigen3_cmake_module>`_
-  * `ros2/python_cmake_module <https://github.com/ros2/python_cmake_module>`_
-  * `ros2/rcutils <https://github.com/ros2/rcutils>`_
-  * `ros2/rcpputils <https://github.com/ros2/rcpputils>`_
-  * `ros2/ros_testing <https://github.com/ros2/ros_testing>`_
+  * `ros2_tracing/tracetools <https://index.ros.org/p/tracetools/>`_
+  * `ros2_tracing/tracetools_read <https://index.ros.org/p/tracetools_read/>`_
+  * `ros2_tracing/tracetools_trace <https://index.ros.org/p/tracetools_trace/>`_
+  * `osrf_pycommon/osrf_pycommon <https://index.ros.org/p/osrf_pycommon/>`_
+  * `osrf_testing_tools_cpp/osrf_testing_tools_cpp <https://index.ros.org/p/osrf_testing_tools_cpp/>`_
+  * `osrf_testing_tools_cpp/test_osrf_testing_tools_cpp <https://index.ros.org/p/test_osrf_testing_tools_cpp/>`_
+  * `class_loader/class_loader <https://index.ros.org/p/class_loader/>`_
+  * `pluginlib/pluginlib <https://index.ros.org/p/pluginlib/>`_
+  * `eigen3_cmake_module/eigen3_cmake_module <https://index.ros.org/p/eigen3_cmake_module/>`_
+  * `python_cmake_module/python_cmake_module <https://index.ros.org/p/python_cmake_module/>`_
+  * `rcutils/rcutils <https://index.ros.org/p/rcutils/>`_
+  * `rcpputils/rcpputils <https://index.ros.org/p/rcpputils/>`_
+  * `ros_testing/ros2test <https://index.ros.org/p/ros2test/>`_
+  * `ros_testing/ros_testing <https://index.ros.org/p/ros_testing/>`_
 
 * ROS interface pipeline
 
-  * `ros2/rosidl <https://github.com/ros2/rosidl>`_
-  * `ros2/rosidl_dds <https://github.com/ros2/rosidl_dds>`_
-  * `ros2/rosidl_defaults <https://github.com/ros2/rosidl_defaults>`_
-  * `ros2/rosidl_python <https://github.com/ros2/rosidl_python>`_
-  * `ros2/rosidl_runtime_py <https://github.com/ros2/rosidl_runtime_py>`_
-  * `ros2/rosidl_typesupport <https://github.com/ros2/rosidl_typesupport>`_
+  * `rosidl/rosidl_adapter <https://index.ros.org/p/rosidl_adapter/>`_
+  * `rosidl/rosidl_cmake <https://index.ros.org/p/rosidl_cmake/>`_
+  * `rosidl/rosidl_generator_c <https://index.ros.org/p/rosidl_generator_c/>`_
+  * `rosidl/rosidl_generator_cpp <https://index.ros.org/p/rosidl_generator_cpp/>`_
+  * `rosidl/rosidl_parser <https://index.ros.org/p/rosidl_parser/>`_
+  * `rosidl/rosidl_runtime_c <https://github.com/ros2/rosidl>`_
+  * `rosidl/rosidl_runtime_cpp <https://github.com/ros2/rosidl>`_
+  * `rosidl/rosidl_typesupport_interface <https://index.ros.org/p/rosidl_typesupport_interface/>`_
+  * `rosidl/rosidl_typesupport_introspection_c <https://index.ros.org/p/rosidl_typesupport_introspection_c/>`_
+  * `rosidl/rosidl_typesupport_introspection_cpp <https://index.ros.org/p/rosidl_typesupport_introspection_cpp/>`_
+  * `rosidl_dds/rosidl_generator_dds_idl <https://index.ros.org/p/rosidl_generator_dds_idl/>`_
+  * `rosidl_defaults/rosidl_default_generators <https://index.ros.org/p/rosidl_default_generators/>`_
+  * `rosidl_defaults/rosidl_default_runtime <https://index.ros.org/p/rosidl_default_runtime/>`_
+  * `rosidl_python/rosidl_generator_py <https://index.ros.org/p/rosidl_generator_py/>`_
+  * `rosidl_runtime_py/rosidl_runtime_py <https://index.ros.org/p/rosidl_runtime_py/>`_
+  * `rosidl_typesupport/rosidl_typesupport_c <https://index.ros.org/p/rosidl_typesupport_c/>`_
+  * `rosidl_typesupport/rosidl_typesupport_cpp <https://index.ros.org/p/rosidl_typesupport_cpp/>`_
 
 * Interface definitions
 
-  * `ros-planning/navigation_msgs <https://github.com/ros-planning/navigation_msgs>`_
-  * `ros2/common_interfaces <https://github.com/ros2/common_interfaces>`_
-  * `ros2/example_interfaces <https://github.com/ros2/example_interfaces>`_
-  * `ros2/rcl_interfaces <https://github.com/ros2/rcl_interfaces>`_
-  * `ros2/test_interface_files <https://github.com/ros2/test_interface_files>`_
-  * `ros2/unique_identifier_msgs <https://github.com/ros2/unique_identifier_msgs>`_
+  * `navigation_msgs/map_msgs <https://index.ros.org/p/map_msgs/>`_
+  * `navigation_msgs/move_base_msgs <https://index.ros.org/p/move_base_msgs/>`_
+  * `common_interfaces/actionlib_msgs <https://index.ros.org/p/actionlib_msgs/>`_
+  * `common_interfaces/common_interfaces <https://index.ros.org/p/common_interfaces/>`_
+  * `common_interfaces/diagnostic_msgs <https://index.ros.org/p/diagnostic_msgs/>`_
+  * `common_interfaces/geometry_msgs <https://index.ros.org/p/geometry_msgs/>`_
+  * `common_interfaces/nav_msgs <https://index.ros.org/p/nav_msgs/>`_
+  * `common_interfaces/sensor_msgs <https://index.ros.org/p/sensor_msgs/>`_
+  * `common_interfaces/shape_msgs <https://index.ros.org/p/shape_msgs/>`_
+  * `common_interfaces/std_msgs <https://index.ros.org/p/std_msgs/>`_
+  * `common_interfaces/std_srvs <https://index.ros.org/p/std_srvs/>`_
+  * `common_interfaces/stereo_msgs <https://index.ros.org/p/stereo_msgs/>`_
+  * `common_interfaces/trajectory_msgs <https://index.ros.org/p/trajectory_msgs/>`_
+  * `common_interfaces/visualization_msgs <https://index.ros.org/p/visualization_msgs/>`_
+  * `example_interfaces/example_interfaces <https://index.ros.org/p/example_interfaces/>`_
+  * `rcl_interfaces/action_msgs <https://index.ros.org/p/action_msgs/>`_
+  * `rcl_interfaces/builtin_interfaces <https://index.ros.org/p/builtin_interfaces/>`_
+  * `rcl_interfaces/composition_interfaces <https://index.ros.org/p/composition_interfaces/>`_
+  * `rcl_interfaces/lifecycle_msgs <https://index.ros.org/p/lifecycle_msgs/>`_
+  * `rcl_interfaces/rcl_interfaces <https://index.ros.org/p/rcl_interfaces/>`_
+  * `rcl_interfaces/rosgraph_msgs <https://index.ros.org/p/rosgraph_msgs/>`_
+  * `rcl_interfaces/statistics_msgs <https://index.ros.org/p/statistics_msgs/>`_
+  * `rcl_interfaces/test_msgs <https://index.ros.org/p/test_msgs/>`_
+  * `test_interface_files/test_interface_files <https://index.ros.org/p/test_interface_files/>`_
+  * `unique_identifier_msgs/unique_identifier_msgs <https://index.ros.org/p/unique_identifier_msgs/>`_
 
 * RMW
 
-  * `ros2/rmw <https://github.com/ros2/rmw>`_
-  * `ros2/rmw_implementation <https://github.com/ros2/rmw_implementation>`_
+  * `rmw/rmw <https://index.ros.org/p/rmw/>`_
+  * `rmw/rmw_implementation_cmake <https://index.ros.org/p/rmw_implementation_cmake/>`_
+  * `rmw_implementation/rmw_implementation <https://index.ros.org/p/rmw_implementation/>`_
   * Connext (Connext itself is not open source)
 
-    * `ros2/rmw_connext <https://github.com/ros2/rmw_connext>`_
-    * `ros2/rosidl_typesupport_connext <https://github.com/ros2/rosidl_typesupport_connext>`_
+    * `rmw_connext/rmw_connext_cpp <https://index.ros.org/p/rmw_connext_cpp/>`_
+    * `rmw_connext/rmw_connext_shared_cpp <https://index.ros.org/p/rmw_connext_shared_cpp/>`_
+    * `rosidl_typesupport_connext/connext_cmake_module <https://index.ros.org/p/connext_cmake_module/>`_
+    * `rosidl_typesupport_connext/rosidl_typesupport_connext_c <https://index.ros.org/p/rosidl_typesupport_connext_c/>`_
+    * `rosidl_typesupport_connext/rosidl_typesupport_connext_cpp <https://index.ros.org/p/rosidl_typesupport_connext_cpp/>`_
 
   * CycloneDDS
 
-    * `eclipse-cyclonedds/cyclonedds <https://github.com/eclipse-cyclonedds/cyclonedds>`_
-    * `ros2/rmw_cyclonedds <https://github.com/ros2/rmw_cyclonedds>`_
+    * `cyclonedds/cyclonedds <https://index.ros.org/p/cyclonedds/>`_
+    * `rmw_cyclonedds/cyclonedds_cmake_module <https://index.ros.org/p/cyclonedds_cmake_module/>`_
+    * `rmw_cyclonedds/rmw_cyclonedds_cpp <https://index.ros.org/p/rmw_cyclonedds_cpp/>`_
 
   * FastRTPS
 
-    * `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-    * `eProsima/Fast-RTPS <https://github.com/eProsima/Fast-RTPS>`_
-    * `ros2/rmw_fastrtps <https://github.com/ros2/rmw_fastrtps>`_
-    * `ros2/rosidl_typesupport_fastrtps <https://github.com/ros2/rosidl_typesupport_fastrtps>`_
+    * `fastcdr/fastcdr <https://index.ros.org/p/fastcdr/>`_
+    * `fastrtps/fastrtps <https://index.ros.org/p/fastrtps/>`_
+    * `rmw_fastrtps/rmw_fastrtps_cpp <https://index.ros.org/p/rmw_fastrtps_cpp/>`_
+    * `rmw_fastrtps/rmw_fastrtps_dynamic_cpp <https://index.ros.org/p/rmw_fastrtps_dynamic_cpp/>`_
+    * `rmw_fastrtps/rmw_fastrtps_shared_cpp <https://index.ros.org/p/rmw_fastrtps_shared_cpp/>`_
+    * `rosidl_typesupport_fastrtps/fastrtps_cmake_module <https://index.ros.org/p/fastrtps_cmake_module/>`_
+    * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_c <https://index.ros.org/p/rosidl_typesupport_fastrtps_c/>`_
+    * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_cpp <https://index.ros.org/p/rosidl_typesupport_fastrtps_cpp/>`_
 
   * OpenSplice
 
-    * `ros2/rmw_opensplice <https://github.com/ros2/rmw_opensplice>`_
-    * `ros2/rosidl_typesupport_opensplice <https://github.com/ros2/rosidl_typesupport_opensplice>`_
+    * `rmw_opensplice/rmw_opensplice_cpp <https://index.ros.org/p/rmw_opensplice_cpp/>`_
+    * `rosidl_typesupport_opensplice/opensplice_cmake_module <https://index.ros.org/p/opensplice_cmake_module/>`_
+    * `rosidl_typesupport_opensplice/rosidl_typesupport_opensplice_c <https://index.ros.org/p/rosidl_typesupport_opensplice_c/>`_
+    * `rosidl_typesupport_opensplice/rosidl_typesupport_opensplice_cpp <https://index.ros.org/p/rosidl_typesupport_opensplice_cpp/>`_
 
 * Client libraries
 
-  * `ros2/rcl <https://github.com/ros2/rcl>`_
-  * `ros2/rcl_logging <https://github.com/ros2/rcl_logging>`_
-  * `ros2/rclcpp <https://github.com/ros2/rclcpp>`_
-  * `ros2/rclpy <https://github.com/ros2/rclpy>`_
+  * `rcl/rcl <https://index.ros.org/p/rcl/>`_
+  * `rcl/rcl_action <https://index.ros.org/p/rcl_action/>`_
+  * `rcl/rcl_lifecycle <https://index.ros.org/p/rcl_lifecycle/>`_
+  * `rcl/rcl_yaml_param_parser <https://index.ros.org/p/rcl_yaml_param_parser/>`_
+  * `rcl_logging/rcl_logging_log4cxx <https://index.ros.org/p/rcl_logging_log4cxx/>`_
+  * `rcl_logging/rcl_logging_noop <https://index.ros.org/p/rcl_logging_noop/>`_
+  * `rcl_logging/rcl_logging_spdlog <https://index.ros.org/p/rcl_logging_spdlog/>`_
+  * `rclcpp/rclcpp <https://index.ros.org/p/rclcpp/>`_
+  * `rclcpp/rclcpp_action <https://index.ros.org/p/rclcpp_action/>`_
+  * `rclcpp/rclcpp_components <https://index.ros.org/p/rclcpp_components/>`_
+  * `rclcpp/rclcpp_lifecycle <https://index.ros.org/p/rclcpp_lifecycle/>`_
+  * `rclpy/rclpy <https://index.ros.org/p/rclpy/>`_
 
 * Orchestration
 
-  * `ros2/launch <https://github.com/ros2/launch>`_
-  * `ros2/launch_ros <https://github.com/ros2/launch_ros>`_
+  * `launch/launch <https://index.ros.org/p/launch/>`_
+  * `launch/launch_testing <https://index.ros.org/p/launch_testing/>`_
+  * `launch/launch_testing_ament_cmake <https://index.ros.org/p/launch_testing_ament_cmake/>`_
+  * `launch/launch_xml <https://index.ros.org/p/launch_xml/>`_
+  * `launch/launch_yaml <https://index.ros.org/p/launch_yaml/>`_
+  * `launch_ros/launch_ros <https://index.ros.org/p/launch_ros/>`_
+  * `launch_ros/launch_testing_ros <https://index.ros.org/p/launch_testing_ros/>`_
+  * `launch_ros/ros2launch <https://index.ros.org/p/ros2launch/>`_
 
 * Features
 
-  * `ros/diagnostics <https://github.com/ros/diagnostics>`_
-  * `ros/xacro <https://github.com/ros/xacro>`_
-  * `ros/robot_state_publisher <https://github.com/ros/robot_state_publisher>`_
+  * `diagnostics/diagnostic_updater <https://index.ros.org/p/diagnostic_updater/>`_
+  * `diagnostics/self_test <https://index.ros.org/p/self_test/>`_
+  * `xacro/xacro <https://index.ros.org/p/xacro/>`_
+  * `robot_state_publisher/robot_state_publisher <https://index.ros.org/p/robot_state_publisher/>`_
   * Sensor processing
 
-    * `ros-perception/image_common <https://github.com/ros-perception/image_common>`_
-    * `ros-perception/image_transport_plugins <https://github.com/ros-perception/image_transport_plugins>`_
-    * `ros-perception/perception_pcl <https://github.com/ros-perception/perception_pcl>`_
-    * `ros-perception/vision_opencv <https://github.com/ros-perception/vision_opencv>`_
-    * `ros-perception/laser_filters <https://github.com/ros-perception/laser_filters>`_
-    * `ros-perception/laser_geometry <https://github.com/ros-perception/laser_geometry>`_
-    * `ros-perception/laser_proc <https://github.com/ros-perception/laser_proc>`_
-    * `ros-perception/depthimage_to_laserscan <https://github.com/ros-perception/depthimage_to_laserscan>`_
+    * `image_common/camera_calibration_parsers <https://index.ros.org/p/camera_calibration_parsers/>`_
+    * `image_common/camera_info_manager <https://index.ros.org/p/camera_info_manager/>`_
+    * `image_common/image_common <https://index.ros.org/p/image_common/>`_
+    * `image_common/image_transport <https://index.ros.org/p/image_transport/>`_
+    * `image_transport_plugins/compressed_depth_image_transport <https://index.ros.org/p/compressed_depth_image_transport/>`_
+    * `image_transport_plugins/compressed_image_transport <https://index.ros.org/p/compressed_image_transport/>`_
+    * `image_transport_plugins/image_transport_plugins <https://index.ros.org/p/image_transport_plugins/>`_
+    * `image_transport_plugins/theora_image_transport <https://index.ros.org/p/theora_image_transport/>`_
+    * `perception_pcl/pcl_conversions <https://index.ros.org/p/pcl_conversions/>`_
+    * `perception_pcl/perception_pcl <https://index.ros.org/p/perception_pcl/>`_
+    * `vision_opencv/cv_bridge <https://index.ros.org/p/cv_bridge/>`_
+    * `vision_opencv/image_geometry <https://index.ros.org/p/image_geometry/>`_
+    * `vision_opencv/vision_opencv <https://index.ros.org/p/vision_opencv/>`_
+    * `laser_filters/laser_filters <https://index.ros.org/p/laser_filters/>`_
+    * `laser_geometry/laser_geometry <https://index.ros.org/p/laser_geometry/>`_
+    * `laser_proc/laser_proc <https://index.ros.org/p/laser_proc/>`_
+    * `depthimage_to_laserscan/depthimage_to_laserscan <https://index.ros.org/p/depthimage_to_laserscan/>`_
 
-  * `ros-planning/navigation2 <https://github.com/ros-planning/navigation2>`_
-  * `ros-planning/moveit2 <https://github.com/ros-planning/moveit2>`_
-  * `ros-visualization/interactive_markers <https://github.com/ros-visualization/interactive_markers>`_
-  * `ros2/geometry2 <https://github.com/ros2/geometry2>`_
-  * `ros2/kdl_parser <https://github.com/ros2/kdl_parser>`_
-  * `ros2/message_filters <https://github.com/ros2/message_filters>`_
-  * `ros2/sros2 <https://github.com/ros2/sros2>`_
-  * `ros2/teleop_twist_joy <https://github.com/ros2/teleop_twist_joy>`_
-  * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_
-  * `ubuntu-robotics/nodl <https://github.com/ubuntu-robotics/nodl>`_
+  * `navigation2/costmap_queue <https://index.ros.org/p/costmap_queue/>`_
+  * `navigation2/dwb_core <https://index.ros.org/p/dwb_core/>`_
+  * `navigation2/dwb_critics <https://index.ros.org/p/dwb_critics/>`_
+  * `navigation2/dwb_msgs <https://index.ros.org/p/dwb_msgs/>`_
+  * `navigation2/dwb_plugins <https://index.ros.org/p/dwb_plugins/>`_
+  * `navigation2/nav2_amcl <https://index.ros.org/p/nav2_amcl/>`_
+  * `navigation2/nav2_behavior_tree <https://index.ros.org/p/nav2_behavior_tree/>`_
+  * `navigation2/nav2_bringup <https://index.ros.org/p/nav2_bringup/>`_
+  * `navigation2/nav2_bt_navigator <https://index.ros.org/p/nav2_bt_navigator/>`_
+  * `navigation2/nav2_common <https://index.ros.org/p/nav2_common/>`_
+  * `navigation2/nav2_controller <https://index.ros.org/p/nav2_controller/>`_
+  * `navigation2/nav2_core <https://index.ros.org/p/nav2_core/>`_
+  * `navigation2/nav2_costmap_2d <https://index.ros.org/p/nav2_costmap_2d/>`_
+  * `navigation2/nav2_dwb_controller <https://index.ros.org/p/nav2_dwb_controller/>`_
+  * `navigation2/nav2_gazebo_spawner <https://index.ros.org/p/nav2_gazebo_spawner/>`_
+  * `navigation2/nav2_lifecycle_manager <https://index.ros.org/p/nav2_lifecycle_manager/>`_
+  * `navigation2/nav2_map_server <https://index.ros.org/p/nav2_map_server/>`_
+  * `navigation2/nav2_msgs <https://index.ros.org/p/nav2_msgs/>`_
+  * `navigation2/nav2_navfn_planner <https://index.ros.org/p/nav2_navfn_planner/>`_
+  * `navigation2/nav2_planner <https://index.ros.org/p/nav2_planner/>`_
+  * `navigation2/nav2_recoveries <https://index.ros.org/p/nav2_recoveries/>`_
+  * `navigation2/nav2_rviz_plugins <https://index.ros.org/p/nav2_rviz_plugins/>`_
+  * `navigation2/nav2_system_tests <https://index.ros.org/p/nav2_system_tests/>`_
+  * `navigation2/nav2_util <https://index.ros.org/p/nav2_util/>`_
+  * `navigation2/nav2_voxel_grid <https://index.ros.org/p/nav2_voxel_grid/>`_
+  * `navigation2/nav2_waypoint_follower <https://index.ros.org/p/nav2_waypoint_follower/>`_
+  * `navigation2/nav_2d_msgs <https://index.ros.org/p/nav_2d_msgs/>`_
+  * `navigation2/nav_2d_utils <https://index.ros.org/p/nav_2d_utils/>`_
+  * `navigation2/navigation2 <https://index.ros.org/p/navigation2/>`_
+  * `ros-planning/moveit2 <https://github.com/ros-planning/moveit2>`_ **(UNMATCHED)**
+  * `interactive_markers/interactive_markers <https://index.ros.org/p/interactive_markers/>`_
+  * `geometry2/examples_tf2_py <https://index.ros.org/p/examples_tf2_py/>`_
+  * `geometry2/geometry2 <https://index.ros.org/p/geometry2/>`_
+  * `geometry2/tf2 <https://index.ros.org/p/tf2/>`_
+  * `geometry2/tf2_bullet <https://index.ros.org/p/tf2_bullet/>`_
+  * `geometry2/tf2_eigen <https://index.ros.org/p/tf2_eigen/>`_
+  * `geometry2/tf2_geometry_msgs <https://index.ros.org/p/tf2_geometry_msgs/>`_
+  * `geometry2/tf2_kdl <https://index.ros.org/p/tf2_kdl/>`_
+  * `geometry2/tf2_msgs <https://index.ros.org/p/tf2_msgs/>`_
+  * `geometry2/tf2_py <https://index.ros.org/p/tf2_py/>`_
+  * `geometry2/tf2_ros <https://index.ros.org/p/tf2_ros/>`_
+  * `geometry2/tf2_sensor_msgs <https://index.ros.org/p/tf2_sensor_msgs/>`_
+  * `geometry2/tf2_tools <https://index.ros.org/p/tf2_tools/>`_
+  * `kdl_parser/kdl_parser <https://index.ros.org/p/kdl_parser/>`_
+  * `message_filters/message_filters <https://index.ros.org/p/message_filters/>`_
+  * `sros2/sros2 <https://index.ros.org/p/sros2/>`_
+  * `sros2/sros2_cmake <https://index.ros.org/p/sros2_cmake/>`_
+  * `teleop_twist_joy/teleop_twist_joy <https://index.ros.org/p/teleop_twist_joy/>`_
+  * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_ **(UNMATCHED)**
+  * `ubuntu-robotics/nodl <https://github.com/ubuntu-robotics/nodl>`_ **(UNMATCHED)**
   * ROS Drivers
 
-    * `ros2/joystick_drivers <https://github.com/ros2/joystick_drivers>`_
-    * `ros-drivers/velodyne <https://github.com/ros-drivers/velodyne>`_
-    * `ros-drivers/urg_c <https://github.com/ros-drivers/urg_c>`_
-    * `ros-drivers/urg_node <https://github.com/ros-drivers/urg_node>`_
-    * `ros-drivers/phidgets_drivers <https://github.com/ros-drivers/phidgets_drivers>`_
-    * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
+    * `joystick_drivers/joy <https://index.ros.org/p/joy/>`_
+    * `velodyne/velodyne <https://index.ros.org/p/velodyne/>`_
+    * `velodyne/velodyne_driver <https://index.ros.org/p/velodyne_driver/>`_
+    * `velodyne/velodyne_laserscan <https://index.ros.org/p/velodyne_laserscan/>`_
+    * `velodyne/velodyne_msgs <https://index.ros.org/p/velodyne_msgs/>`_
+    * `velodyne/velodyne_pointcloud <https://index.ros.org/p/velodyne_pointcloud/>`_
+    * `urg_c/urg_c <https://index.ros.org/p/urg_c/>`_
+    * `urg_node/urg_node <https://index.ros.org/p/urg_node/>`_
+    * `phidgets_drivers/libphidget22 <https://index.ros.org/p/libphidget22/>`_
+    * `phidgets_drivers/phidgets_accelerometer <https://index.ros.org/p/phidgets_accelerometer/>`_
+    * `phidgets_drivers/phidgets_analog_inputs <https://index.ros.org/p/phidgets_analog_inputs/>`_
+    * `phidgets_drivers/phidgets_api <https://index.ros.org/p/phidgets_api/>`_
+    * `phidgets_drivers/phidgets_digital_inputs <https://index.ros.org/p/phidgets_digital_inputs/>`_
+    * `phidgets_drivers/phidgets_digital_outputs <https://index.ros.org/p/phidgets_digital_outputs/>`_
+    * `phidgets_drivers/phidgets_drivers <https://index.ros.org/p/phidgets_drivers/>`_
+    * `phidgets_drivers/phidgets_gyroscope <https://index.ros.org/p/phidgets_gyroscope/>`_
+    * `phidgets_drivers/phidgets_high_speed_encoder <https://index.ros.org/p/phidgets_high_speed_encoder/>`_
+    * `phidgets_drivers/phidgets_ik <https://index.ros.org/p/phidgets_ik/>`_
+    * `phidgets_drivers/phidgets_magnetometer <https://index.ros.org/p/phidgets_magnetometer/>`_
+    * `phidgets_drivers/phidgets_motors <https://index.ros.org/p/phidgets_motors/>`_
+    * `phidgets_drivers/phidgets_msgs <https://index.ros.org/p/phidgets_msgs/>`_
+    * `phidgets_drivers/phidgets_spatial <https://index.ros.org/p/phidgets_spatial/>`_
+    * `phidgets_drivers/phidgets_temperature <https://index.ros.org/p/phidgets_temperature/>`_
+    * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_ **(UNMATCHED)**
 
 * Documentation, Examples, Tutorials
 
-  * `ros2/demos <https://github.com/ros2/demos>`_
-  * `ros2/design <https://github.com/ros2/design>`_
-  * `ros2/examples <https://github.com/ros2/examples>`_
-  * `ros2/ros_core_documentation <https://github.com/ros2/ros_core_documentation>`_
-  * `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`_
+  * `demos/action_tutorials_cpp <https://index.ros.org/p/action_tutorials_cpp/>`_
+  * `demos/action_tutorials_interfaces <https://index.ros.org/p/action_tutorials_interfaces/>`_
+  * `demos/action_tutorials_py <https://index.ros.org/p/action_tutorials_py/>`_
+  * `demos/composition <https://index.ros.org/p/composition/>`_
+  * `demos/demo_nodes_cpp <https://index.ros.org/p/demo_nodes_cpp/>`_
+  * `demos/demo_nodes_cpp_native <https://index.ros.org/p/demo_nodes_cpp_native/>`_
+  * `demos/demo_nodes_py <https://index.ros.org/p/demo_nodes_py/>`_
+  * `demos/dummy_map_server <https://index.ros.org/p/dummy_map_server/>`_
+  * `demos/dummy_robot_bringup <https://index.ros.org/p/dummy_robot_bringup/>`_
+  * `demos/dummy_sensors <https://index.ros.org/p/dummy_sensors/>`_
+  * `demos/image_tools <https://index.ros.org/p/image_tools/>`_
+  * `demos/intra_process_demo <https://index.ros.org/p/intra_process_demo/>`_
+  * `demos/lifecycle <https://index.ros.org/p/lifecycle/>`_
+  * `demos/logging_demo <https://index.ros.org/p/logging_demo/>`_
+  * `demos/pendulum_control <https://index.ros.org/p/pendulum_control/>`_
+  * `demos/pendulum_msgs <https://index.ros.org/p/pendulum_msgs/>`_
+  * `demos/quality_of_service_demo_cpp <https://index.ros.org/p/quality_of_service_demo_cpp/>`_
+  * `demos/quality_of_service_demo_py <https://index.ros.org/p/quality_of_service_demo_py/>`_
+  * `demos/topic_monitor <https://index.ros.org/p/topic_monitor/>`_
+  * `ros2/design <https://github.com/ros2/design>`_ **(UNMATCHED)**
+  * `examples/examples_rclcpp_minimal_action_client <https://index.ros.org/p/examples_rclcpp_minimal_action_client/>`_
+  * `examples/examples_rclcpp_minimal_action_server <https://index.ros.org/p/examples_rclcpp_minimal_action_server/>`_
+  * `examples/examples_rclcpp_minimal_client <https://index.ros.org/p/examples_rclcpp_minimal_client/>`_
+  * `examples/examples_rclcpp_minimal_composition <https://index.ros.org/p/examples_rclcpp_minimal_composition/>`_
+  * `examples/examples_rclcpp_minimal_publisher <https://index.ros.org/p/examples_rclcpp_minimal_publisher/>`_
+  * `examples/examples_rclcpp_minimal_service <https://index.ros.org/p/examples_rclcpp_minimal_service/>`_
+  * `examples/examples_rclcpp_minimal_subscriber <https://index.ros.org/p/examples_rclcpp_minimal_subscriber/>`_
+  * `examples/examples_rclcpp_minimal_timer <https://index.ros.org/p/examples_rclcpp_minimal_timer/>`_
+  * `examples/examples_rclcpp_multithreaded_executor <https://index.ros.org/p/examples_rclcpp_multithreaded_executor/>`_
+  * `examples/examples_rclpy_executors <https://index.ros.org/p/examples_rclpy_executors/>`_
+  * `examples/examples_rclpy_minimal_action_client <https://index.ros.org/p/examples_rclpy_minimal_action_client/>`_
+  * `examples/examples_rclpy_minimal_action_server <https://index.ros.org/p/examples_rclpy_minimal_action_server/>`_
+  * `examples/examples_rclpy_minimal_client <https://index.ros.org/p/examples_rclpy_minimal_client/>`_
+  * `examples/examples_rclpy_minimal_publisher <https://index.ros.org/p/examples_rclpy_minimal_publisher/>`_
+  * `examples/examples_rclpy_minimal_service <https://index.ros.org/p/examples_rclpy_minimal_service/>`_
+  * `examples/examples_rclpy_minimal_subscriber <https://index.ros.org/p/examples_rclpy_minimal_subscriber/>`_
+  * `ros2/ros_core_documentation <https://github.com/ros2/ros_core_documentation>`_ **(UNMATCHED)**
+  * `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`_ **(UNMATCHED)**
 
 * Robot
 
-  * `ros/urdfdom_headers <https://github.com/ros/urdfdom_headers>`_
-  * `ros2/urdf <https://github.com/ros2/urdf>`_
-  * `ros2/urdfdom <https://github.com/ros2/urdfdom>`_
+  * `urdfdom_headers/urdfdom_headers <https://index.ros.org/p/urdfdom_headers/>`_
+  * `urdf/urdf <https://index.ros.org/p/urdf/>`_
+  * `urdfdom/urdfdom <https://index.ros.org/p/urdfdom/>`_
 
 * Tools
 
-  * `ros-simulation/gazebo_ros_pkgs <https://github.com/ros-simulation/gazebo_ros_pkgs>`_
-  * `ros2/ros1_bridge <https://github.com/ros2/ros1_bridge>`_
-  * `ros2/ros2cli <https://github.com/ros2/ros2cli>`_
-  * `ros2/rosbag2 <https://github.com/ros2/rosbag2>`_
-  * `ros2/rviz <https://github.com/ros2/rviz>`_
-  * `ros-tooling/cross_compile <https://github.com/ros-tooling/cross_compile>`_
-  * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_
-  * `ApexAI/performance_test <https://gitlab.com/ApexAI/performance_test>`_
+  * `gazebo_ros_pkgs/gazebo_dev <https://index.ros.org/p/gazebo_dev/>`_
+  * `gazebo_ros_pkgs/gazebo_msgs <https://index.ros.org/p/gazebo_msgs/>`_
+  * `gazebo_ros_pkgs/gazebo_plugins <https://index.ros.org/p/gazebo_plugins/>`_
+  * `gazebo_ros_pkgs/gazebo_ros <https://index.ros.org/p/gazebo_ros/>`_
+  * `gazebo_ros_pkgs/gazebo_ros_pkgs <https://index.ros.org/p/gazebo_ros_pkgs/>`_
+  * `ros1_bridge/ros1_bridge <https://index.ros.org/p/ros1_bridge/>`_
+  * `ros2cli/ros2action <https://index.ros.org/p/ros2action/>`_
+  * `ros2cli/ros2cli <https://index.ros.org/p/ros2cli/>`_
+  * `ros2cli/ros2component <https://index.ros.org/p/ros2component/>`_
+  * `ros2cli/ros2doctor <https://index.ros.org/p/ros2doctor/>`_
+  * `ros2cli/ros2interface <https://index.ros.org/p/ros2interface/>`_
+  * `ros2cli/ros2lifecycle <https://index.ros.org/p/ros2lifecycle/>`_
+  * `ros2cli/ros2lifecycle_test_fixtures <https://index.ros.org/p/ros2lifecycle_test_fixtures/>`_
+  * `ros2cli/ros2multicast <https://index.ros.org/p/ros2multicast/>`_
+  * `ros2cli/ros2node <https://index.ros.org/p/ros2node/>`_
+  * `ros2cli/ros2param <https://index.ros.org/p/ros2param/>`_
+  * `ros2cli/ros2pkg <https://index.ros.org/p/ros2pkg/>`_
+  * `ros2cli/ros2run <https://index.ros.org/p/ros2run/>`_
+  * `ros2cli/ros2service <https://index.ros.org/p/ros2service/>`_
+  * `ros2cli/ros2topic <https://index.ros.org/p/ros2topic/>`_
+  * `rosbag2/ros2bag <https://index.ros.org/p/ros2bag/>`_
+  * `rosbag2/rosbag2 <https://index.ros.org/p/rosbag2/>`_
+  * `rosbag2/rosbag2_converter_default_plugins <https://index.ros.org/p/rosbag2_converter_default_plugins/>`_
+  * `rosbag2/rosbag2_storage <https://index.ros.org/p/rosbag2_storage/>`_
+  * `rosbag2/rosbag2_storage_default_plugins <https://index.ros.org/p/rosbag2_storage_default_plugins/>`_
+  * `rosbag2/rosbag2_test_common <https://index.ros.org/p/rosbag2_test_common/>`_
+  * `rosbag2/rosbag2_tests <https://index.ros.org/p/rosbag2_tests/>`_
+  * `rosbag2/rosbag2_transport <https://index.ros.org/p/rosbag2_transport/>`_
+  * `rosbag2/shared_queues_vendor <https://index.ros.org/p/shared_queues_vendor/>`_
+  * `rosbag2/sqlite3_vendor <https://index.ros.org/p/sqlite3_vendor/>`_
+  * `rviz/rviz2 <https://index.ros.org/p/rviz2/>`_
+  * `rviz/rviz_assimp_vendor <https://index.ros.org/p/rviz_assimp_vendor/>`_
+  * `rviz/rviz_common <https://index.ros.org/p/rviz_common/>`_
+  * `rviz/rviz_default_plugins <https://index.ros.org/p/rviz_default_plugins/>`_
+  * `rviz/rviz_ogre_vendor <https://index.ros.org/p/rviz_ogre_vendor/>`_
+  * `rviz/rviz_rendering <https://index.ros.org/p/rviz_rendering/>`_
+  * `rviz/rviz_rendering_tests <https://index.ros.org/p/rviz_rendering_tests/>`_
+  * `rviz/rviz_visual_testing_framework <https://index.ros.org/p/rviz_visual_testing_framework/>`_
+  * `cross_compile/cross_compile <https://github.com/ros-tooling/cross_compile>`_
+  * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_ **(UNMATCHED)**
+  * `ApexAI/performance_test <https://gitlab.com/ApexAI/performance_test>`_ **(UNMATCHED)**
   * RQt
 
-    * `ros-visualization/python_qt_binding <https://github.com/ros-visualization/python_qt_binding>`_
-    * `ros-visualization/qt_gui_core <https://github.com/ros-visualization/qt_gui_core>`_
-    * `ros-visualization/rqt <https://github.com/ros-visualization/rqt>`_
-    * `ros-visualization/rqt_action <https://github.com/ros-visualization/rqt_action>`_
-    * `ros-visualization/rqt_console <https://github.com/ros-visualization/rqt_console>`_
-    * `ros-visualization/rqt_graph <https://github.com/ros-visualization/rqt_graph>`_
-    * `ros-visualization/rqt_image_view <https://github.com/ros-visualization/rqt_image_view>`_
-    * `ros-visualization/rqt_msg <https://github.com/ros-visualization/rqt_msg>`_
-    * `ros-visualization/rqt_plot <https://github.com/ros-visualization/rqt_plot>`_
-    * `ros-visualization/rqt_publisher <https://github.com/ros-visualization/rqt_publisher>`_
-    * `ros-visualization/rqt_py_console <https://github.com/ros-visualization/rqt_py_console>`_
-    * `ros-visualization/rqt_reconfigure <https://github.com/ros-visualization/rqt_reconfigure>`_
-    * `ros-visualization/rqt_robot_steering <https://github.com/ros-visualization/rqt_robot_steering>`_
-    * `ros-visualization/rqt_service_caller <https://github.com/ros-visualization/rqt_service_caller>`_
-    * `ros-visualization/rqt_srv <https://github.com/ros-visualization/rqt_srv>`_
-    * `ros-visualization/rqt_tf_tree <https://github.com/ros-visualization/rqt_tf_tree>`_
-    * `ros-visualization/rqt_topic <https://github.com/ros-visualization/rqt_topic>`_
+    * `python_qt_binding/python_qt_binding <https://index.ros.org/p/python_qt_binding/>`_
+    * `qt_gui_core/qt_dotgraph <https://index.ros.org/p/qt_dotgraph/>`_
+    * `qt_gui_core/qt_gui <https://index.ros.org/p/qt_gui/>`_
+    * `qt_gui_core/qt_gui_app <https://index.ros.org/p/qt_gui_app/>`_
+    * `qt_gui_core/qt_gui_core <https://index.ros.org/p/qt_gui_core/>`_
+    * `qt_gui_core/qt_gui_cpp <https://index.ros.org/p/qt_gui_cpp/>`_
+    * `qt_gui_core/qt_gui_py_common <https://index.ros.org/p/qt_gui_py_common/>`_
+    * `rqt/rqt <https://index.ros.org/p/rqt/>`_
+    * `rqt/rqt_gui <https://index.ros.org/p/rqt_gui/>`_
+    * `rqt/rqt_gui_cpp <https://index.ros.org/p/rqt_gui_cpp/>`_
+    * `rqt/rqt_gui_py <https://index.ros.org/p/rqt_gui_py/>`_
+    * `rqt/rqt_py_common <https://index.ros.org/p/rqt_py_common/>`_
+    * `rqt_action/rqt_action <https://index.ros.org/p/rqt_action/>`_
+    * `rqt_console/rqt_console <https://index.ros.org/p/rqt_console/>`_
+    * `rqt_graph/rqt_graph <https://index.ros.org/p/rqt_graph/>`_
+    * `rqt_image_view/rqt_image_view <https://index.ros.org/p/rqt_image_view/>`_
+    * `rqt_msg/rqt_msg <https://index.ros.org/p/rqt_msg/>`_
+    * `rqt_plot/rqt_plot <https://index.ros.org/p/rqt_plot/>`_
+    * `rqt_publisher/rqt_publisher <https://index.ros.org/p/rqt_publisher/>`_
+    * `rqt_py_console/rqt_py_console <https://index.ros.org/p/rqt_py_console/>`_
+    * `rqt_reconfigure/rqt_reconfigure <https://index.ros.org/p/rqt_reconfigure/>`_
+    * `rqt_robot_steering/rqt_robot_steering <https://index.ros.org/p/rqt_robot_steering/>`_
+    * `rqt_service_caller/rqt_service_caller <https://index.ros.org/p/rqt_service_caller/>`_
+    * `rqt_srv/rqt_srv <https://index.ros.org/p/rqt_srv/>`_
+    * `rqt_tf_tree/rqt_tf_tree <https://index.ros.org/p/rqt_tf_tree/>`_
+    * `rqt_topic/rqt_topic <https://index.ros.org/p/rqt_topic/>`_
 
 
 Copyright

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -49,12 +49,12 @@ The list should be self-contained and exhaustive: if a package appears on the li
 Change process
 ==============
 
-This content is maintained at GitHub in the [REP repo](https://github.com/ros-infrastructure/rep).
+This content is maintained at GitHub in the `REP repo <https://github.com/ros-infrastructure/rep>`_.
 To propose changes, such as adding or removing items, make a pull request (PR) to that repo.
 The ensuing public review and discussion will evaluate the change in light of the purpose and scope explained above.
 The final merge decision on a given PR will be made by the ROS 2 Technical Steering Committee (TSC) by a simple voting process:
 
-* Each TSC member organization may vote on a PR by commenting with a score according to the [REP voting guidelines](https://www.ros.org/reps/rep-0010.html#voting-scores).
+* Each TSC member organization may vote on a PR by commenting with a score according to the `REP voting guidelines <https://www.ros.org/reps/rep-0010.html#voting-scores>`_.
 * A TSC member may update their vote (e.g., following changes or discussion) with a new comment while the PR remains under review (i.e., before it has been merged); the new vote takes the place of the old one.
 * The PR will be merged if and when the sum of TSC member vote values is **>= 3** (votes of `+0` and `-0` are treated equally as 0 when computing the sum).
 * The PR will be declined if it becomes numerically impossible based on existing votes to meet the minimum vote threshold.

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -40,7 +40,8 @@ The list below is curated to include repositories that are:
 We aim that all of these repositories are also:
 
 * actively maintained and following accepted software development processes, including code review and testing; and
-* at Quality Level 3 or better, as defined in REP 2004.
+* at Quality Level 3 or better, as defined in REP 2004; and
+* are maintained by an organization or at least two individuals.
 
 The list should be self-contained and exhaustive: if a package appears on the list, then all of its ROS 2 dependencies must also appear on the list (third-party or system dependencies should not be included).
 
@@ -73,8 +74,7 @@ All else being equal, we prefer to include packages that:
 
 * have clear evidence of reuse (e.g., declared dependencies elsewhere in ROS 2, stars or forks at GitHub, public user testimonials); and/or
 * represent substantially new and important features that are reasonably expected to come into wide use but are not yet ready; and/or
-* are demonstrably of high quality (e.g., via conformance with REP 2004); and/or
-* are maintained by an organization or at least two individuals.
+* are demonstrably of high quality (e.g., via conformance with REP 2004).
 
 We prefer not to include packages that meet none of these criteria.
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -263,13 +263,6 @@ All items on the list for the next distro should already be released into the ro
     * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_c <https://index.ros.org/p/rosidl_typesupport_fastrtps_c/>`_
     * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_cpp <https://index.ros.org/p/rosidl_typesupport_fastrtps_cpp/>`_
 
-  * OpenSplice
-
-    * `rmw_opensplice/rmw_opensplice_cpp <https://index.ros.org/p/rmw_opensplice_cpp/>`_
-    * `rosidl_typesupport_opensplice/opensplice_cmake_module <https://index.ros.org/p/opensplice_cmake_module/>`_
-    * `rosidl_typesupport_opensplice/rosidl_typesupport_opensplice_c <https://index.ros.org/p/rosidl_typesupport_opensplice_c/>`_
-    * `rosidl_typesupport_opensplice/rosidl_typesupport_opensplice_cpp <https://index.ros.org/p/rosidl_typesupport_opensplice_cpp/>`_
-
 * Client libraries
 
   * `rcl/rcl <https://index.ros.org/p/rcl/>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -153,6 +153,7 @@ Content
 
   * `ros/diagnostics <https://github.com/ros/diagnostics>`_
   * `ros/xacro <https://github.com/ros/xacro>`_
+  * `ros/robot_state_publisher <https://github.com/ros/robot_state_publisher>`_
   * Sensor processing
 
     * `ros-perception/image_common <https://github.com/ros-perception/image_common>`_
@@ -161,6 +162,7 @@ Content
     * `ros-perception/vision_opencv <https://github.com/ros-perception/vision_opencv>`_
     * `ros-perception/laser_filters <https://github.com/ros-perception/laser_filters>`_
     * `ros-perception/laser_geometry <https://github.com/ros-perception/laser_geometry>`_
+    * `ros-perception/depthimage_to_laserscan <https://github.com/ros-perception/depthimage_to_laserscan>`_
 
   * `ros-planning/navigation2 <https://github.com/ros-planning/navigation2>`_
   * `ros-planning/moveit2 <https://github.com/ros-planning/moveit2>`_
@@ -178,6 +180,8 @@ Content
     * `ros-drivers/velodyne <https://github.com/ros-drivers/velodyne>`_
     * `ros-drivers/urg_c <https://github.com/ros-drivers/urg_c>`_
     * `ros-drivers/urg_node <https://github.com/ros-drivers/urg_node>`_
+    * `ros-drivers/phidgets_drivers <https://github.com/ros-drivers/phidgets_drivers>`_
+    * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
 
 * Documentation, Examples, Tutorials
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -11,7 +11,7 @@ Post-History:
 Abstract
 ========
 
-This REP describes a set of repositories which together form the common packages of ROS 2.
+This REP describes the common packages of ROS 2.
 
 
 Motivation
@@ -30,14 +30,14 @@ Furthermore, we encourage contributors to focus their efforts on items from this
 Scope
 =====
 
-The list below is curated to include repositories that are:
+The list below is curated to include packages that are:
 
 * open source (not proprietary);
 * connected to the ROS 2 project (not general purpose software, except when included with ROS 2-specific bindings);
 * broadly usable (not narrowly tailored for uncommon use cases); and
 * evidently used by a nontrivial part of the community.
 
-We aim that all of these repositories are also:
+We aim that all of these packages are also:
 
 * actively maintained and following accepted software development processes, including code review and testing; and
 * at Quality Level 3 or better, as defined in REP 2004; and
@@ -85,6 +85,8 @@ Content
 The common packages may vary among distros; unless otherwise annotated below, each package in the list is **available since Foxy Fitzroy**.
 When planning starts for a new distro, the package list from the previous distro will be copied in as a starting point.
 All items on the list for the next distro should already be released into the rolling distro; as a bootstrapping exception, items on the list for Foxy may take some time to be released.
+
+**TODO: expand the repositories below to individual packages**
 
 * Buildsystem, package index and tooling around
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -62,6 +62,7 @@ Content
   * `ros/ros_environment <https://github.com/ros/ros_environment>`_
   * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_
   * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_
+  * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_
   * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_
   * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_
   * `ros2/ament_cmake_ros <https://github.com/ros2/ament_cmake_ros>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -167,8 +167,11 @@ All items on the list for the next distro should already be released into the ro
 
 * Utility functionality
 
+  * `ros2_tracing/ros2trace <https://index.ros.org/p/ros2trace/>`_
   * `ros2_tracing/tracetools <https://index.ros.org/p/tracetools/>`_
+  * `ros2_tracing/tracetools_launch <https://index.ros.org/p/tracetools_launch/>`_
   * `ros2_tracing/tracetools_read <https://index.ros.org/p/tracetools_read/>`_
+  * `ros2_tracing/tracetools_test <https://index.ros.org/p/tracetools_test/>`_
   * `ros2_tracing/tracetools_trace <https://index.ros.org/p/tracetools_trace/>`_
   * `osrf_pycommon/osrf_pycommon <https://index.ros.org/p/osrf_pycommon/>`_
   * `osrf_testing_tools_cpp/osrf_testing_tools_cpp <https://index.ros.org/p/osrf_testing_tools_cpp/>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -73,7 +73,7 @@ All else being equal, we prefer to include packages that:
 
 * have clear evidence of reuse (e.g., declared dependencies elsewhere in ROS 2, stars or forks at GitHub, public user testimonials); and/or
 * represent substantially new and important features that are reasonably expected to come into wide use but are not yet ready; and/or
-* meet a high quality standard as defined in REP 2004; and/or
+* are demonstrably of high quality (e.g., via conformance with REP 2004); and/or
 * are maintained by an organization or at least two individuals.
 
 We prefer not to include packages that meet none of these criteria.

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -1,0 +1,235 @@
+REP: 2005
+Title: ROS 2 Standard Library
+Author: Brian Gerkey <gerkey@openrobotics.org>, Dirk Thomas <dthomas@openrobotics.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 12-Jan-2020
+Post-History:
+
+
+Abstract
+========
+
+This REP describes a set of repositories which together form the standard library of ROS 2.
+
+
+Motivation
+==========
+
+Like ROS 1 before it, ROS 2 follows a federated development model.
+The open source code and other assets that make up the ROS 2 project are spread across multiple repositories, with different authors, maintainers, and contributors to each component.
+This federated model makes it easy for developers to share their contributions with the community while also retaining control over how those contributions are developed and released.
+As a result the community size and overall project scope can scale up naturally and efficiently.
+
+But in exchange, it can be difficult in a federated ecosystem for users and developers to know, of all the available ROS 2 packages, which are integral to the project.
+With the curated list below we aim to provide community members with guidance regarding which parts of the ROS 2 ecosystem are widely used, actively maintained, and of high quality.
+Furthermore, we encourage contributors to focus their efforts on items from this list.
+
+
+Scope
+=====
+
+The list below is curated to include repositories that are:
+
+* open source (not proprietary);
+* connected to the ROS 2 project (not general purpose software, except when included with ROS 2-specific bindings);
+* broadly usable (not narrowly tailored for uncommon use cases); and
+* evidently used by a nontrivial part of the community.
+
+We aim that all of these repositories are also:
+
+* actively maintained and following accepted software development processes, including code review and testing.
+
+
+Change process
+==============
+
+This content is maintained at GitHub in the [REP repo](https://github.com/ros-infrastructure/rep).
+To propose changes, such as adding or removing items, make a pull request to that repo.
+The ensuing public review and discussion will evaluate the change in light of the purpose and scope explained above, with the final merge decision being made by one of the REP maintainers.
+
+
+Content
+=======
+
+* Buildsystem, package index and tooling around
+
+  * `ament/ament_cmake <https://github.com/ament/ament_cmake>`_
+  * `ament/ament_index <https://github.com/ament/ament_index>`_
+  * `ament/ament_package <https://github.com/ament/ament_package>`_
+  * `ament/ament_lint <https://github.com/ament/ament_lint>`_
+  * `ros/ros_environment <https://github.com/ros/ros_environment>`_
+  * `ros-infrastructure/bloom <https://github.com/ros-infrastructure/bloom>`_
+  * `ros-infrastructure/catkin_pkg <https://github.com/ros-infrastructure/catkin_pkg>`_
+  * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_
+  * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_
+  * `ros2/ament_cmake_ros <https://github.com/ros2/ament_cmake_ros>`_
+
+* Third party packages
+
+  * `eProsima/foonathan_memory_vendor <https://github.com/eProsima/foonathan_memory_vendor>`_
+  * `ament/googletest <https://github.com/ament/googletest>`_
+  * `ament/uncrustify_vendor <https://github.com/ament/uncrustify_vendor>`_
+  * `ros2/console_bridge_vendor <https://github.com/ros2/console_bridge_vendor>`_
+  * `ros2/poco_vendor <https://github.com/ros2/poco_vendor>`_
+  * `ros2/spdlog_vendor <https://github.com/ros2/spdlog_vendor>`_
+  * `ros2/tinydir_vendor <https://github.com/ros2/tinydir_vendor>`_
+  * `ros2/tinyxml_vendor <https://github.com/ros2/tinyxml_vendor>`_
+  * `ros2/tinyxml2_vendor <https://github.com/ros2/tinyxml2_vendor>`_
+  * `ros2/yaml_cpp_vendor <https://github.com/ros2/yaml_cpp_vendor>`_
+
+* Utility functionality
+
+  * `micro-ROS/ros_tracing/ros2_tracing <https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing>`_
+  * `osrf/osrf_pycommon <https://github.com/osrf/osrf_pycommon>`_
+  * `osrf/osrf_testing_tools_cpp <https://github.com/osrf/osrf_testing_tools_cpp>`_
+  * `ros/class_loader <https://github.com/ros/class_loader>`_
+  * `ros/pluginlib <https://github.com/ros/pluginlib>`_
+  * `ros2/eigen3_cmake_module <https://github.com/ros2/eigen3_cmake_module>`_
+  * `ros2/python_cmake_module <https://github.com/ros2/python_cmake_module>`_
+  * `ros2/rcutils <https://github.com/ros2/rcutils>`_
+  * `ros2/rcpputils <https://github.com/ros2/rcpputils>`_
+  * `ros2/ros_testing <https://github.com/ros2/ros_testing>`_
+
+* ROS interface pipeline
+
+  * `ros2/rosidl <https://github.com/ros2/rosidl>`_
+  * `ros2/rosidl_dds <https://github.com/ros2/rosidl_dds>`_
+  * `ros2/rosidl_defaults <https://github.com/ros2/rosidl_defaults>`_
+  * `ros2/rosidl_python <https://github.com/ros2/rosidl_python>`_
+  * `ros2/rosidl_runtime_py <https://github.com/ros2/rosidl_runtime_py>`_
+  * `ros2/rosidl_typesupport <https://github.com/ros2/rosidl_typesupport>`_
+
+* Interface definitions
+
+  * `ros-planning/navigation_msgs <https://github.com/ros-planning/navigation_msgs>`_
+  * `ros2/common_interfaces <https://github.com/ros2/common_interfaces>`_
+  * `ros2/example_interfaces <https://github.com/ros2/example_interfaces>`_
+  * `ros2/rcl_interfaces <https://github.com/ros2/rcl_interfaces>`_
+  * `ros2/test_interface_files <https://github.com/ros2/test_interface_files>`_
+  * `ros2/unique_identifier_msgs <https://github.com/ros2/unique_identifier_msgs>`_
+
+* RMW
+
+  * `ros2/rmw <https://github.com/ros2/rmw>`_
+  * `ros2/rmw_implementation <https://github.com/ros2/rmw_implementation>`_
+  * Connext (Connext itself is not open source)
+
+    * `ros2/rmw_connext <https://github.com/ros2/rmw_connext>`_
+    * `ros2/rosidl_typesupport_connext <https://github.com/ros2/rosidl_typesupport_connext>`_
+
+  * CycloneDDS
+
+    * `eclipse-cyclonedds/cyclonedds <https://github.com/eclipse-cyclonedds/cyclonedds>`_
+    * `ros2/rmw_cyclonedds <https://github.com/ros2/rmw_cyclonedds>`_
+
+  * FastRTPS
+
+    * `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
+    * `eProsima/Fast-RTPS <https://github.com/eProsima/Fast-RTPS>`_
+    * `ros2/rmw_fastrtps <https://github.com/ros2/rmw_fastrtps>`_
+    * `ros2/rosidl_typesupport_fastrtps <https://github.com/ros2/rosidl_typesupport_fastrtps>`_
+
+  * OpenSplice
+
+    * `ros2/rmw_opensplice <https://github.com/ros2/rmw_opensplice>`_
+    * `ros2/rosidl_typesupport_opensplice <https://github.com/ros2/rosidl_typesupport_opensplice>`_
+
+* Client libraries
+
+  * `ros2/rcl <https://github.com/ros2/rcl>`_
+  * `ros2/rcl_logging <https://github.com/ros2/rcl_logging>`_
+  * `ros2/rclcpp <https://github.com/ros2/rclcpp>`_
+  * `ros2/rclpy <https://github.com/ros2/rclpy>`_
+
+* Orchestration
+
+  * `ros2/launch <https://github.com/ros2/launch>`_
+  * `ros2/launch_ros <https://github.com/ros2/launch_ros>`_
+
+* Features
+
+  * `ros/xacro <https://github.com/ros/xacro>`_
+  * Sensor processing
+
+    * `ros-perception/image_common <https://github.com/ros-perception/image_common>`_
+    * `ros-perception/image_transport_plugins <https://github.com/ros-perception/image_transport_plugins>`_
+    * `ros-perception/perception_pcl <https://github.com/ros-perception/perception_pcl>`_
+    * `ros-perception/vision_opencv <https://github.com/ros-perception/vision_opencv>`_
+    * `ros-perception/laser_filters <https://github.com/ros-perception/laser_filters>`_
+    * `ros-perception/laser_geometry <https://github.com/ros-perception/laser_geometry>`_
+
+  * `ros-planning/navigation2 <https://github.com/ros-planning/navigation2>`_
+  * `ros-planning/moveit2 <https://github.com/ros-planning/moveit2>`_
+  * `ros-visualization/interactive_markers <https://github.com/ros-visualization/interactive_markers>`_
+  * `ros2/geometry2 <https://github.com/ros2/geometry2>`_
+  * `ros2/kdl_parser <https://github.com/ros2/kdl_parser>`_
+  * `ros2/message_filters <https://github.com/ros2/message_filters>`_
+  * `ros2/sros2 <https://github.com/ros2/sros2>`_
+  * `ros2/teleop_twist_joy <https://github.com/ros2/teleop_twist_joy>`_
+  * ROS Drivers
+
+    * `ros2/joystick_drivers <https://github.com/ros2/joystick_drivers>`_
+    * `ros-drivers/velodyne <https://github.com/ros-drivers/velodyne>`_
+    * `ros-drivers/urg_c <https://github.com/ros-drivers/urg_c>`_
+    * `ros-drivers/urg_node <https://github.com/ros-drivers/urg_node>`_
+
+* Documentation, Examples, Tutorials
+
+  * `ros2/demos <https://github.com/ros2/demos>`_
+  * `ros2/design <https://github.com/ros2/design>`_
+  * `ros2/examples <https://github.com/ros2/examples>`_
+  * `ros2/ros_core_documentation <https://github.com/ros2/ros_core_documentation>`_
+  * `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`_
+
+* Robot
+
+  * `ros/urdfdom_headers <https://github.com/ros/urdfdom_headers>`_
+  * `ros2/urdf <https://github.com/ros2/urdf>`_
+  * `ros2/urdfdom <https://github.com/ros2/urdfdom>`_
+
+* Tools
+
+  * `ros-simulation/gazebo_ros_pkgs <https://github.com/ros-simulation/gazebo_ros_pkgs>`_
+  * `ros2/ros1_bridge <https://github.com/ros2/ros1_bridge>`_
+  * `ros2/ros2cli <https://github.com/ros2/ros2cli>`_
+  * `ros2/rosbag2 <https://github.com/ros2/rosbag2>`_
+  * `ros2/rviz <https://github.com/ros2/rviz>`_
+  * `ros-tooling/cross_compile <https://github.com/ros-tooling/cross_compile>`_
+  * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_
+  * RQt
+
+    * `ros-visualization/python_qt_binding <https://github.com/ros-visualization/python_qt_binding>`_
+    * `ros-visualization/qt_gui_core <https://github.com/ros-visualization/qt_gui_core>`_
+    * `ros-visualization/rqt <https://github.com/ros-visualization/rqt>`_
+    * `ros-visualization/rqt_action <https://github.com/ros-visualization/rqt_action>`_
+    * `ros-visualization/rqt_console <https://github.com/ros-visualization/rqt_console>`_
+    * `ros-visualization/rqt_graph <https://github.com/ros-visualization/rqt_graph>`_
+    * `ros-visualization/rqt_image_view <https://github.com/ros-visualization/rqt_image_view>`_
+    * `ros-visualization/rqt_msg <https://github.com/ros-visualization/rqt_msg>`_
+    * `ros-visualization/rqt_plot <https://github.com/ros-visualization/rqt_plot>`_
+    * `ros-visualization/rqt_publisher <https://github.com/ros-visualization/rqt_publisher>`_
+    * `ros-visualization/rqt_py_console <https://github.com/ros-visualization/rqt_py_console>`_
+    * `ros-visualization/rqt_reconfigure <https://github.com/ros-visualization/rqt_reconfigure>`_
+    * `ros-visualization/rqt_robot_steering <https://github.com/ros-visualization/rqt_robot_steering>`_
+    * `ros-visualization/rqt_service_caller <https://github.com/ros-visualization/rqt_service_caller>`_
+    * `ros-visualization/rqt_srv <https://github.com/ros-visualization/rqt_srv>`_
+    * `ros-visualization/rqt_tf_tree <https://github.com/ros-visualization/rqt_tf_tree>`_
+    * `ros-visualization/rqt_topic <https://github.com/ros-visualization/rqt_topic>`_
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -150,6 +150,7 @@ Content
 
 * Features
 
+  * `ros/diagnostics <https://github.com/ros/diagnostics>`_
   * `ros/xacro <https://github.com/ros/xacro>`_
   * Sensor processing
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -162,6 +162,7 @@ Content
     * `ros-perception/vision_opencv <https://github.com/ros-perception/vision_opencv>`_
     * `ros-perception/laser_filters <https://github.com/ros-perception/laser_filters>`_
     * `ros-perception/laser_geometry <https://github.com/ros-perception/laser_geometry>`_
+    * `ros-perception/laser_proc <https://github.com/ros-perception/laser_proc>`_
     * `ros-perception/depthimage_to_laserscan <https://github.com/ros-perception/depthimage_to_laserscan>`_
 
   * `ros-planning/navigation2 <https://github.com/ros-planning/navigation2>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -293,8 +293,10 @@ All items on the list for the next distro should already be released into the ro
 
   * `diagnostics/diagnostic_updater <https://index.ros.org/p/diagnostic_updater/>`_
   * `diagnostics/self_test <https://index.ros.org/p/self_test/>`_
-  * `xacro/xacro <https://index.ros.org/p/xacro/>`_
+  * `joint_state_publisher/joint_state_publisher <https://index.ros.org/p/joint_state_publisher/>`_
+  * `joint_state_publisher/joint_state_publisher_gui <https://index.ros.org/p/joint_state_publisher_gui/>`_
   * `robot_state_publisher/robot_state_publisher <https://index.ros.org/p/robot_state_publisher/>`_
+  * `xacro/xacro <https://index.ros.org/p/xacro/>`_
   * Sensor processing
 
     * `image_common/camera_calibration_parsers <https://index.ros.org/p/camera_calibration_parsers/>`_

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -1,5 +1,5 @@
 REP: 2005
-Title: ROS 2 Standard Library
+Title: ROS 2 Common Packages
 Author: Brian Gerkey <gerkey@openrobotics.org>, Dirk Thomas <dthomas@openrobotics.org>
 Status: Active
 Type: Informational
@@ -11,7 +11,7 @@ Post-History:
 Abstract
 ========
 
-This REP describes a set of repositories which together form the standard library of ROS 2.
+This REP describes a set of repositories which together form the common packages of ROS 2.
 
 
 Motivation
@@ -23,7 +23,7 @@ This federated model makes it easy for developers to share their contributions w
 As a result the community size and overall project scope can scale up naturally and efficiently.
 
 But in exchange, it can be difficult in a federated ecosystem for users and developers to know, of all the available ROS 2 packages, which are integral to the project.
-With the curated list below we aim to provide community members with guidance regarding which parts of the ROS 2 ecosystem are widely used, actively maintained, and of high quality.
+With the curated list below we aim to provide community members with guidance regarding which parts of the ROS 2 ecosystem are widely used, actively maintained, and of sufficient quality to be relied upon.
 Furthermore, we encourage contributors to focus their efforts on items from this list.
 
 
@@ -39,19 +39,52 @@ The list below is curated to include repositories that are:
 
 We aim that all of these repositories are also:
 
-* actively maintained and following accepted software development processes, including code review and testing.
+* actively maintained and following accepted software development processes, including code review and testing; and
+* at Quality Level 3 or better, as defined in REP 2004.
+
+The list should be self-contained and exhaustive: if a package appears on the list, then all of its ROS 2 dependencies must also appear on the list (third-party or system dependencies should not be included).
 
 
 Change process
 ==============
 
 This content is maintained at GitHub in the [REP repo](https://github.com/ros-infrastructure/rep).
-To propose changes, such as adding or removing items, make a pull request to that repo.
-The ensuing public review and discussion will evaluate the change in light of the purpose and scope explained above, with the final merge decision being made by one of the REP maintainers.
+To propose changes, such as adding or removing items, make a pull request (PR) to that repo.
+The ensuing public review and discussion will evaluate the change in light of the purpose and scope explained above.
+The final merge decision on a given PR will be made by the ROS 2 Technical Steering Committee (TSC) by a simple voting process:
+
+* Each TSC member organization may vote on a PR by commenting with a score according to the [REP voting guidelines](https://www.ros.org/reps/rep-0010.html#voting-scores).
+* A TSC member may update their vote (e.g., following changes or discussion) with a new comment while the PR remains under review (i.e., before it has been merged); the new vote takes the place of the old one.
+* The PR will be merged if and when the sum of TSC member vote values is **>= 3** (votes of `+0` and `-0` are treated equally as 0 when computing the sum).
+* The PR will be declined if it becomes numerically impossible based on existing votes to meet the minimum vote threshold.
+* The proposer will be encouraged to withdraw a PR if after a significant amount the time the minimum vote threshold is still not met.
+
+For example, if a PR garners the following 6 votes from TSC members: `+1`, `+1`, `-1`, `+0`, `+1`, `+1`, then the sum would be 3 and the PR would be merged.
+
+The minimum vote threshold necessary to merge a PR may be changed by a majority vote of the TSC.
+
+
+Guidance on changes
+===================
+
+We wish for this list to grow steadily over time, but not to become an indiscriminate collection of all ROS 2 software.
+Our goal with this list is **curation**: we want to ensure that the contents are meaningful to the developer and user community.
+All else being equal, we prefer to include packages that:
+
+* have clear evidence of reuse (e.g., declared dependencies elsewhere in ROS 2, stars or forks at GitHub, public user testimonials); and/or
+* represent substantially new and important features that are reasonably expected to come into wide use but are not yet ready; and/or
+* meet a high quality standard as defined in REP 2004; and/or
+* are maintained by an organization or at least two individuals.
+
+We prefer not to include packages that meet none of these criteria.
 
 
 Content
 =======
+
+The common packages may vary among distros; unless otherwise annotated below, each package in the list is **available since Foxy Fitzroy**.
+When planning starts for a new distro, the package list from the previous distro will be copied in as a starting point.
+All items on the list for the next distro should already be released into the rolling distro; as a bootstrapping exception, items on the list for Foxy may take some time to be released.
 
 * Buildsystem, package index and tooling around
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -200,6 +200,7 @@ Content
   * `ros2/rviz <https://github.com/ros2/rviz>`_
   * `ros-tooling/cross_compile <https://github.com/ros-tooling/cross_compile>`_
   * `ros-tooling/system_metrics_collector <https://github.com/ros-tooling/system_metrics_collector>`_
+  * `ApexAI/performance_test <https://gitlab.com/ApexAI/performance_test>`_
   * RQt
 
     * `ros-visualization/python_qt_binding <https://github.com/ros-visualization/python_qt_binding>`_


### PR DESCRIPTION
This REP defines a curated list of ROS 2 repositories to provide community members with guidance regarding which parts of the ROS 2 ecosystem are widely used, actively maintained, and of high quality. Furthermore, we encourage contributors to focus their efforts on items from this list.

The naming "Standard Library" is following the same term of the [Python Standard Library](https://docs.python.org/3/library/) (but is up for discussion if a different term is proposed which describes the content better).