### PR TITLE
Add joint_state_publisher_gui to REP-150.

### DIFF
--- a/rep-0150.rst
+++ b/rep-0150.rst
@@ -143,8 +143,8 @@ Both of these variants contain tutorials for the stacks they provide.
 
   - desktop:
       extends: [robot, viz]
-      packages: [angles, common_tutorials, geometry_tutorials, ros_tutorials,
-                 roslint, urdf_tutorial, visualization_tutorials]
+      packages: [angles, common_tutorials, geometry_tutorials, joint_state_publisher_gui,
+                 ros_tutorials, roslint, urdf_tutorial, visualization_tutorials]
   - desktop_full:
       extends: [desktop, perception, simulators]
       packages: [urdf_sim_tutorial]


### PR DESCRIPTION
This is to move a GUI dependency out of the robot
metapackage.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>

This goes along with https://github.com/ros/metapackages/pull/30