### PR TITLE
Force xmlschema < 1.1 for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.6"
-# command to install dependencies
-install:
-  - pip install docutils
-  - pip install xmlschema
+jobs:
+  include:
+  - python: "2.7"
+    install:
+    - pip install docutils
+    - pip install xmlschema<1.1
+  - python: "3.6"
+    install:
+    - pip install docutils
+    - pip install xmlschema
 # command to run tests
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
-jobs:
-  include:
-  - python: "2.7"
-    install:
-    - pip install docutils
-    - pip install "xmlschema<1.1"
-  - python: "3.6"
-    install:
-    - pip install docutils
-    - pip install xmlschema
+python:
+  - "2.7"
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install docutils
+  # xmlschema 1.1 dropped support for Python 2
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then pip install "xmlschema<1.1"; else pip install xmlschema; fi
 # command to run tests
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
   - python: "2.7"
     install:
     - pip install docutils
-    - pip install xmlschema<1.1
+    - pip install "xmlschema<1.1"
   - python: "3.6"
     install:
     - pip install docutils


### PR DESCRIPTION
`xmlschema` 1.1.0 (released Jan 23 2020) dropped support for Python 2. This has been breaking CI builds.

Note that I am explicitly listing the two jobs rather than using Travis' matrix expansion as before, so that we can still get up-to-date versions of `xmlschema` for Python 3 builds.

If you'd prefer to use the same `xmlschema` version for both builds, this PR can be simplified to a just adding: `<1.1` on line 8.