### PR TITLE
REP 2004 extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
 # command to install dependencies
 install:
   - pip install docutils
-  - pip install xmlschema
+  # xmlschema 1.1 dropped support for Python 2
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then pip install "xmlschema<1.1"; else pip install xmlschema; fi
 # command to run tests
 script:
   - make

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -92,8 +92,8 @@ Requirements to be considered a 'Level 1' package:
 #. **Change Control Process:**
 
    #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-   #. Must have `Developer Certificate of Origin (DCO) <https://developercertificate.org/>`_ on pull requests
-   #. Must have peer review policy for all change requests (e.g. require one or more reviewer)
+   #. Must have confirmation of contributor origin (e.g. `DCO  <https://developercertificate.org/>`_, CLA, etc.)
+   #. Must have peer review policy for all change requests (e.g. require one or more reviewers)
    #. Must have Continuous Integration (CI) policy for all change requests
    #. Must have documentation policy for all change requests
 
@@ -142,6 +142,8 @@ Refer to the detailed description of the requirements below the chart for more i
 
 Quality Level Comparison Chart
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The chart below compares Quality Levels 1 through 4 relative to the Level 1 requirements' numbering scheme above.
 
 ✓ = required
 
@@ -204,7 +206,7 @@ Quality Level Comparison Chart
       -
     * - 2.ii
       - ✓
-      -
+      - ✓
       -
       -
       -
@@ -347,7 +349,7 @@ Version Policy
 The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
 For example, ``semver`` covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community.
 
-The policy should link changes to API and ABI to the version scheme.
+The version policy should link public API changes, which may also impact ABI, to changes in the version number.
 
 For the ROS ecosystem, the version policy needs to state that API and ABI will be maintained within a stable ROS distribution.
 Following ``semver``, this means only patch and minor increases only into an existing ROS distribution.
@@ -392,7 +394,7 @@ If the users feel that the justifications are insufficient or incorrect, they ca
 
 There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
 These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
-This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
+This document will not prescribe how or where these lists should be hosted, but one possibility is an informational REP, continually updated and versioned with each new ROS distribution.
 
 Feature Testing and Code Coverage Policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -405,8 +407,8 @@ The policy may be influenced by factors like:
 - what strategy is preferred for dealing with difficult to reach statements/branches
 
 Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
-Among those reasons is satisfying stakeholders [2]_, which is main goal of requiring a code coverage policy for high quality packages.
-A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
+Among those reasons is satisfying stakeholders [2]_, which is the main goal of requiring a code coverage policy for high quality packages.
+A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of proving to stakeholders that the package is properly tested.
 
 The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
 This at least gives you and your stakeholders some confidence that all feature have basic tests.
@@ -461,6 +463,7 @@ Requirements to be considered a 'Level 2' package:
 #. **Change Control Process:**
 
    #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have confirmation of contributor origin (e.g. `DCO  <https://developercertificate.org/>`_, CLA, etc.)
    #. Must have Continuous Integration (CI) policy for all change requests
 
 #. **Documentation:**
@@ -536,7 +539,7 @@ Requirements to be considered a 'Level 3' package:
 
 #. **Dependencies:**
 
-   #. May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should be documented
+   #. May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should still be documented in the quality declaration
 
 #. **Platform Support:**
 

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -13,6 +13,7 @@ Abstract
 
 This REP describes a set of categories meant to convey the quality or maturity of packages in the ROS ecosystem.
 Inclusion in a category, or quality level, is based on the policies to which a package adheres.
+The categories address version, change control, documentation, testing, and platform support policies.
 
 Motivation
 ==========
@@ -57,55 +58,6 @@ There are four quality levels described below, each roughly described as:
 
 While each quality level will have different requirements, it's always possible to overachieve in certain requirements even if other requirements prevent a package from moving up to the next quality level.
 
-.. try chart here
-
-  .. list-table:: Quality Levels
-     :widths: 25 25 50
-     :header-rows: 1
-
-     * - Policy
-       - Quality Level 1
-       - Quality Level 2
-       - Quality Level 3
-       - Quality Level 4
-       - Quality Level 5
-     * - Version
-       -
-       -
-       -
-       -
-       -
-     * - Change Control
-       -
-       -
-       -
-       -
-       -
-     * - Testing
-       -
-       -
-       -
-       -
-       -
-     * - Documentation
-       -
-       -
-       -
-       -
-       -
-     * - Dependencies
-       -
-       -
-       -
-       -
-       -
-     * - Platform Support
-       -
-       -
-       -
-       -
-       -
-
 Quality Level 1
 ^^^^^^^^^^^^^^^
 
@@ -128,10 +80,6 @@ Package Requirements
 
 Requirements to be considered a 'Level 1' package:
 
-.. is it necessary to write out the numbers for any reason? like when it's rendered here: https://www.ros.org/reps/rep-0000.html will there be a problem? or if the nested lists should include the parent number (2.1, 2.1.1, etc.)?
-
-.. also, if we do a chart/table, would that replace these bullet lists or be in addition to them? try both, see how it looks/reads
-
 #. **Version Policy:**
 
    #. Must have a version policy (e.g. ``semver``)
@@ -148,8 +96,6 @@ Requirements to be considered a 'Level 1' package:
    #. Must have peer review policy for all change requests (e.g. require one or more reviewer)
    #. Must have Continuous Integration (CI) policy for all change requests
    #. Must have documentation policy for all change requests
-
-.. DCO only in level 1?
 
 #. **Documentation:**
 
@@ -192,12 +138,112 @@ Requirements to be considered a 'Level 1' package:
    #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 If the above points are satisfied then a package can be considered 'Level 1'.
-Refer to the detailed description of the requirements in the Rationale section below for more information.
+Refer to the detailed description of the requirements below for more information.
+
+Version Policy
+~~~~~~~~~~~~~~
+
+The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
+For example, ``semver`` covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community.
+
+The policy should link changes to API and ABI to the version scheme.
+
+For the ROS ecosystem, the version policy needs to state that API and ABI will be maintained within a stable ROS distribution.
+Following ``semver``, this means only patch and minor increases only into an existing ROS distribution.
+
+Public API
+""""""""""
+
+The package documentation should state what the public API includes, and/or state what parts of the API are excluded intentionally.
+
+For C++, it's assumed that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
+For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
+Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
+
+For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
+One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
+
+There are also other, non-API, things which should be considered and documented as part of the "stable interface" of the package.
+These could include, but aren't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
+
+For other languages the details will be different, but the important thing is that the public API be obviously documented, and the public API adheres to a documented and tested API and ABI stability policy, as described in the version policy.
+
+Feature Documentation
+~~~~~~~~~~~~~~~~~~~~~
+
+For each feature provided by the public API of the package, or by a tool in the package, there must be corresponding user documentation.
+The term "feature", and the scope of the documentation, is intentionally vague because it's difficult to quantitatively measure this metric.
+In general, for a 'Level 1' quality package, all of the things a user might do with the package need at least basic documentation or a snippet of code as an example on how to use it.
+The `roscpp Overview <https://wiki.ros.org/roscpp/Overview>`_ from the ROS 1 wiki is a good example of this kind of documentation.
+
+Quality Declaration and Claim
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each package claiming a quality level should include a "quality declaration" document.
+This declaration should include a claimed quality level and then should have a section for each of the requirements in that claimed quality level justifying how the package meets each of those requirements.
+
+Sometimes the justification will be a link to a policy documented in the package itself or it may link to a common policy used by a group of packages.
+If there is additional evidence that these policies are being followed, that should be included as well, e.g. a link to the coverage statistics for the package to show that coverage is being tracked and maintained.
+Other times, justification will be an explanation as to why a requirement was not met or does not apply, e.g. if performance tests do not make sense for the package in question, it should be satisfactorily explained.
+
+There is no enforcement or checking of these claims, but instead it's just sufficient to present this information to potential users.
+If the users feel that the justifications are insufficient or incorrect, they can open issues against the repository and resolve it with the maintainers.
+
+There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
+These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
+This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
+
+Feature Testing and Code Coverage Policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
+The policy may be influenced by factors like:
+
+- what programming languages are being used, and whether or not there are multiple languages in use
+- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
+- what strategy is preferred for dealing with difficult to reach statements/branches
+
+Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
+Among those reasons is satisfying stakeholders [2]_, which is main goal of requiring a code coverage policy for high quality packages.
+A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
+
+The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
+This at least gives you and your stakeholders some confidence that all feature have basic tests.
+Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
+
+Performance Testing
+~~~~~~~~~~~~~~~~~~~
+
+There are some cases where performance testing does not make sense to have.
+For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
+
+However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent unintended performance degradation.
+Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
+
+Dependencies
+^^^^^^^^^^^^
+
+Each package should examine the quality levels of their direct runtime dependencies.
+Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
+
+An example of an exception would be build or "build tool" dependencies, which are only used during build time and do not affect the runtime quality of the package.
+This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also affect the quality of the runtime product directly.
+Conversely, this would include something like CMake, which in most ways does not affect the quality of the product.
+
+Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
+Dependencies which are not other "ROS" packages should be individually examined for quality.
+You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
+The argument could be text justification, or it could link to other analyses or discussions had by community members rationalizing the choice.
+
+For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'Level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'Level 1' quality standard, then your package's "quality declaration" document should mention this as well.
+This could be accomplished simply by saying that one of your dependencies, ``rclcpp``, has some caveats and then linking to ``rclcpp``'s own "quality declaration".
+
+There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they affect the quality of a package.
+The goal is for the maintainers of a package to "make the case" that their dependencies are at least as high quality as the package in question.
+They should examine each dependency, and document any important caveats or justified exceptions in the package's "quality declaration" document so peer reviewers and consumers of the package can make their own evaluations.
 
 Quality Level 2
 ^^^^^^^^^^^^^^^
-
-.. would it make more sense to have levels 2+ just say what's different from level 1? try that
 
 These are packages which need to be solidly developed and might be used in production environments, but are not strictly required, or are commonly replaced by custom solutions.
 This can also include packages which are not yet up to 'Level 1' but intend to be in the future.
@@ -249,7 +295,7 @@ Requirements to be considered a 'Level 2' package:
    #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 If the above points are satisfied then a package can be considered 'Level 2'.
-Refer to the detailed description of the requirements in the Rationale section below for more information.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
 
 Quality Level 3
 ^^^^^^^^^^^^^^^
@@ -296,7 +342,7 @@ Requirements to be considered a 'Level 3' package:
    #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 If the above points are satisfied then a package can be considered 'Level 3'.
-Refer to the detailed description of the requirements in the Rationale section below for more information.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
 
 Quality Level 4
 ^^^^^^^^^^^^^^^
@@ -336,7 +382,7 @@ Requirements to be considered a 'Level 4' package:
    #. May support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 Any package that does not claim to be 'Level 3' or higher is automatically 'Level 4'.
-Refer to the detailed description of the requirements in the Rationale section below for more information.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
 
 Quality Level 5
 ^^^^^^^^^^^^^^^
@@ -351,133 +397,6 @@ Since these categories are applied on a per package basis, and since there may b
 This is recommended rather than trying to mix processes depending on which packages are changed in a given change request (pull request or merge request, etc.).
 If this is too onerous, then it's recommended to split lower quality packages out into a separate repository.
 
-Rationale
-=========
-
-.. might move this back to specification section, remove rationale section
-
-.. also, there's no explanation for change control process. might be unnecessary but looks inconsistent
-
-Version Policy
-^^^^^^^^^^^^^^
-
-The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
-We recommend the use of ``semver`` as it covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community broadly.
-
-The policy should link changes to API and ABI to the version scheme.
-
-Additionally, specifically for the ROS ecosystem, the policy should state that API and ABI will be maintained within a stable ROS distribution.
-For ``semver``, this means only patch and minor increases only into an existing ROS distribution.
-
-Public API
-~~~~~~~~~~
-
-The package documentation should state what the public API includes, and/or state what parts of the API are excluded intentionally.
-
-For C++, it's assumed that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
-For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
-Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
-
-For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
-One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
-
-There are also other, non-API, things which should be considered and optionally documented as part of the "stable interface" of the package.
-This includes, but isn't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
-
-For other languages the details will be different, but the important thing is that the public API be obviously documented, and the public API adheres to a documented and tested API and ABI stability policy, as described in the version policy.
-
-Feature Documentation
-^^^^^^^^^^^^^^^^^^^^^
-
-For each feature provided by the public API of the package, or by a tool in the package, there must be corresponding user documentation.
-The term "feature", and the scope of the documentation, is intentionally vague because it's difficult to quantitatively measure this metric.
-However, the spirit of this requirement is that, for a 'Level 1' quality package, all of the things a user might do with the package needs at least basic documentation or a snippet of code as an example on how to use it.
-The `roscpp Overview <https://wiki.ros.org/roscpp/Overview>`_ from the ROS 1 wiki is a good example of this kind of documentation.
-
-Quality Declaration and Claim
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Each package claiming a quality level should have a "quality declaration" documented somewhere.
-This declaration should include a claimed quality level and then should have a section for each of the requirements in that claimed quality level justifying how the package meets each of those requirements.
-
-Sometimes the justification will be a link to a policy documented in the package itself or it may link to a common policy used by a group of packages.
-If there is additional evidence that these policies are being followed, that should be included as well, e.g. a link to the coverage statistics for the package to show that coverage is being tracked and maintained.
-Other times, justification will be an explanation as to why a requirement was not met or does not apply, e.g. if performance tests do not make sense for the package in question, it should be satisfactorily explained.
-
-There is no enforcement or checking of these claims, but instead it's just sufficient to present this information to potential users.
-If the users feel that the justifications are insufficient or incorrect, they can open issues against the repository and resolve it with the maintainers.
-
-There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
-These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
-This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
-
-Feature Testing and Code Coverage Policy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
-The policy may be influenced by factors like:
-
-- what programming languages are being used, and whether or not there are multiple languages in use
-- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
-- what strategy is preferred for dealing with difficult to reach statements/branches
-
-Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
-Among those reasons is satisfying stakeholders [2]_, which is this REP's main goal for requiring a code coverage policy for high quality packages.
-A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
-
-The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
-This at least gives you and your stakeholders some confidence that all feature have basic tests.
-Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
-
-Performance Testing
-^^^^^^^^^^^^^^^^^^^
-
-There are some cases where performance testing does not make sense to have.
-For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
-
-However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent unintended performance degradation.
-Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
-
-Dependencies
-^^^^^^^^^^^^
-
-Each package should examine their direct runtime dependencies for their quality levels.
-Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
-
-An example of this would be build or "build tool" dependencies, which are only used during build time and do not affect the runtime quality of the package.
-This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also affect the quality of the runtime product directly.
-This would include, for another example, something like CMake, which in most ways does not affect the quality of the product.
-
-There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they affect the quality of a package.
-However, the point is to require the maintainers of the package to examine each dependency, justify why they do or do not affect quality, and document that so that peer reviewers and consumers of the package can make their own evaluation.
-
-Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
-
-Dependencies which are not other "ROS" packages should be individually examined for quality.
-You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
-In either case, for each direct "non-ROS" dependency your "quality declaration" should include a justification as to why it is acceptable to depend on this software and still claim your package's level of quality.
-This may simply be text justification, or it may link to other analysis or discussions had by community members rationalizing the choice.
-The important point is that each dependency is considered, justified, and that the justification is documented, so that users of the package can read the justification and decide for themselves if it is acceptable or not.
-
-Any important caveats or justified exceptions for your dependencies should be mentioned (or referenced) in your own package's "quality declaration" document.
-
-For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'Level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'Level 1' quality standard, then your package's "quality declaration" document should mention this as well.
-Perhaps just saying that one of your dependencies, ``rclcpp``, has some caveats and then link to ``rclcpp``'s own "quality declaration".
-
-In this way, caveats and justifications that may be important for peer reviewers and consumers of your package to understand can "bubble up" from any part of the system.
-
-The goal here is for the maintainer of a package to "make the case" to potential users or stakeholders that their dependencies are at least as high quality as the package in question, and to make a best effort attempt to make them aware of any issues or caveats.
-It's up to those users and stakeholders to evaluate that justification and to look at the dependencies themselves as well.
-
-
-Backwards Compatibility
-=======================
-
-.. this entire section can be removed if there are in fact no backwards compatibility concerns
-
-Since there are no preceding standards in this space, at least in the ROS community, of which we are aware, there are no backwards compatibility concerns.
-
-
 Reference Implementation
 ========================
 
@@ -489,8 +408,6 @@ The `rcutils package's quality declaration <https://github.com/ros2/rcutils/pull
 
 Quality Declaration Template
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. possible location for the template. another option is having a folder for rep2004 and putting the file in there, and linking from the reference implementation section. some other reps have folders with images. might be "cleaner" and still technically "self-contained". also easier for others to reference or copy.
 
 .. code-block:: markdown
 
@@ -548,8 +465,6 @@ References and Footnotes
 
 .. [2] What is a reasonable code coverage % for unit tests (and why)?
    https://stackoverflow.com/a/34698711/671658
-
-.. does linking like that ^ still interfere with the "same license" thing? https://creativecommons.org/licenses/by-sa/4.0/
 
 Copyright
 =========

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -221,7 +221,7 @@ However, if performance is a reasonable concern for use in a production system, 
 Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
 
 Dependencies
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 Each package should examine the quality levels of their direct runtime dependencies.
 Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -509,7 +509,7 @@ Quality Level Comparison Chart
     * - 3.v.a
       - ✓
       - ✓
-      - ●
+      - ✓
       -
       -
     * - 3.v.b

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -320,10 +320,6 @@ Requirements to be considered a 'Level 3' package:
    #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
    #. Must have Continuous Integration (CI) policy for all change requests
 
-#. **Testing:**
-
-   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
-
 #. **Documentation:**
 
    #. Must have a declared license or set of licenses
@@ -332,6 +328,10 @@ Requirements to be considered a 'Level 3' package:
 
       #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
       #. *May register with a centralized list of 'Level 3' packages, if one exists, to allow for peer review of the claim*
+
+#. **Testing:**
+
+   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
 
 #. **Dependencies:**
 

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -57,6 +57,55 @@ There are four quality levels described below, each roughly described as:
 
 While each quality level will have different requirements, it's always possible to overachieve in certain requirements even if other requirements prevent a package from moving up to the next quality level.
 
+.. try chart here
+
+.. list-table:: Quality Levels
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Policy
+     - Quality Level 1
+     - Quality Level 2
+     - Quality Level 3
+     - Quality Level 4
+     - Quality Level 5
+   * - Version
+     -
+     -
+     -
+     -
+     -
+   * - Change Control
+     -
+     -
+     -
+     -
+     -
+   * - Testing
+     -
+     -
+     -
+     -
+     -
+   * - Documentation
+     -
+     -
+     -
+     -
+     -
+   * - Dependencies
+     -
+     -
+     -
+     -
+     -
+   * - Platform Support
+     -
+     -
+     -
+     -
+     -
+
 Quality Level 1
 ^^^^^^^^^^^^^^^
 
@@ -499,6 +548,8 @@ References and Footnotes
 
 .. [2] What is a reasonable code coverage % for unit tests (and why)?
    https://stackoverflow.com/a/34698711/671658
+
+.. does linking like that ^ still interfere with the "same license" thing? https://creativecommons.org/licenses/by-sa/4.0/
 
 Copyright
 =========

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -59,52 +59,52 @@ While each quality level will have different requirements, it's always possible 
 
 .. try chart here
 
-.. list-table:: Quality Levels
-   :widths: 25 25 50
-   :header-rows: 1
+  .. list-table:: Quality Levels
+     :widths: 25 25 50
+     :header-rows: 1
 
-   * - Policy
-     - Quality Level 1
-     - Quality Level 2
-     - Quality Level 3
-     - Quality Level 4
-     - Quality Level 5
-   * - Version
-     -
-     -
-     -
-     -
-     -
-   * - Change Control
-     -
-     -
-     -
-     -
-     -
-   * - Testing
-     -
-     -
-     -
-     -
-     -
-   * - Documentation
-     -
-     -
-     -
-     -
-     -
-   * - Dependencies
-     -
-     -
-     -
-     -
-     -
-   * - Platform Support
-     -
-     -
-     -
-     -
-     -
+     * - Policy
+       - Quality Level 1
+       - Quality Level 2
+       - Quality Level 3
+       - Quality Level 4
+       - Quality Level 5
+     * - Version
+       -
+       -
+       -
+       -
+       -
+     * - Change Control
+       -
+       -
+       -
+       -
+       -
+     * - Testing
+       -
+       -
+       -
+       -
+       -
+     * - Documentation
+       -
+       -
+       -
+       -
+       -
+     * - Dependencies
+       -
+       -
+       -
+       -
+       -
+     * - Platform Support
+       -
+       -
+       -
+       -
+       -
 
 Quality Level 1
 ^^^^^^^^^^^^^^^

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -11,32 +11,36 @@ Post-History: 17-Dec-2019
 Abstract
 ========
 
-This REP describes a set of categories which are meant to convey the quality, or at least the maturity, of packages in the ROS ecosystem.
-Inclusion in one category or another is based on the policies to which the packages adhere.
-The categories are meant to give some expectation as to the quality of a package and allows the maintainers to be more strict with some packages and less so with others.
+This REP describes a set of categories meant to convey the quality or maturity of packages in the ROS ecosystem.
+Inclusion in a category, or quality level, is based on the policies to which a package adheres.
 
-The purpose of these categories is not to enforce quality, but to set expectations for consumers of the packages and to encourage maintainers of the packages to document how their package's policies achieve that quality level.
-The documented policies allow consumers of the packages to consider any caveats for the package or its dependencies when deciding whether or not the package meets the standards for their project.
+Motivation
+==========
 
+The purpose of this REP is to provide standard guidelines regarding package quality, for both maintainers and consumers.
+
+The categories are meant to set quality expectations for package consumers, not to enforce quality rules on maintainers.
+Package maintainers are responsible for establishing processes and documenting how their package's policies achieve a certain quality level.
+With the help of documented policies, package consumers can better evaluate whether a package or its dependencies meet the standards for use in their projects.
+
+By providing these rough goals for package maintainers to strive towards, the categories will also encourage better quality across the ROS ecosystem.
 
 Specification
 =============
-
-The categories also provide rough goals for packages to strive towards, encouraging better quality across the ecosystem.
 
 There are four quality levels described below, each roughly described as:
 
 * Quality Level 1:
 
   * highest quality level
-  * packages which are needed for production systems
+  * packages that are needed for production systems
   * e.g. ``rclcpp``, ``urdf``, ``tf2``, etc.
 
 * Quality Level 2:
 
-  * high quality packages which are either:
+  * high quality packages that are either:
 
-    * on the way to level 1 or
+    * on the way to 'Level 1', or
     * are general solutions used by many people, but are only sometimes used for production systems
 
   * e.g. ``navigation2``, ``rosbag2``, etc.
@@ -57,12 +61,13 @@ Quality Level 1
 ^^^^^^^^^^^^^^^
 
 This category should be used for packages which are required for a reasonable ROS system in a production environment.
-That is to say that after you remove development tools, build tools, and introspection tools, these packages are still left over as requirements for a basic ROS system to run.
-However, that does not mean that packages that would not normally fit this description should never be called 'Level 1'.
-If there is a need for a particular package in a reasonable production scenario, then that package should be considered for this category as well.
-However, packages which we consider essential to getting a robot up and running quickly, but perhaps is a generic solution to the problem should probably not start out as 'Level 1' due to the high effort in getting a package to 'Level 1' and maintaining it there.
+These are the packages that remain as requirements for a basic ROS system to run after you remove development tools, build tools, and introspection tools.
 
-For example, the packages which provide intra-process communication, inter-process communication, generated message runtime code, node lifecycle, etc. should probably all be considered for 'Level 1'.
+Packages that would not normally fit this description can still be called 'Level 1'.
+If there is a need for a particular package in a reasonable production scenario, then that package should be considered for this category as well.
+However, packages which we consider essential to getting a robot up and running quickly, but perhaps provide a generic solution to a problem should probably not start out as 'Level 1' due to the high effort in getting a package to 'Level 1' and maintaining it there.
+
+For example, packages which provide intra-process communication, inter-process communication, generated message runtime code, node lifecycle, etc. should probably all be considered for 'Level 1'.
 However, a package which provides pose estimation (like ``robot_pose_ekf``\ ) is a generic solution for something that most people need, but is often replaced with a domain specific solution in production, and therefore it should probably not start out as 'Level 1'.
 However, it may upgrade to it at a later date, if it proves to be a solution that people want to use in their products.
 
@@ -72,101 +77,240 @@ For example, it may be the case the tool which launches and verifies a ROS graph
 Package Requirements
 ~~~~~~~~~~~~~~~~~~~~
 
-*Note: bullets below that start with [ROS Core], will be the prescription for what we do in the core packages in order to meet the associated requirements*
-
 Requirements to be considered a 'Level 1' package:
 
-* Version Policy:
+.. is it necessary to write out the numbers for any reason? like when it's rendered here: https://www.ros.org/reps/rep-0000.html will there be a problem? or if the nested lists should include the parent number (2.1, 2.1.1, etc.)?
 
-  * Must have a version policy (e.g. ``semver``)
-  * Must be at a stable version (e.g. for ``semver`` that means have a version >= 1.0.0)
-  * Must have a strictly declared public API
-  * Must have a policy for API stability
-  * Must have a policy for ABI stability
-  * Must have a policy that keeps API and ABI stability within a released ROS Distribution
-  * [ROS Core] will use ``semver``, will maintain API and ABI stability according to ``semver`` and will be ABI (and therefore API) stable within a ROS distribution
+.. also, if we do a chart/table, would that replace these bullet lists or be in addition to them? try both, see how it looks/reads
 
-* Change Control Process:
+#. **Version Policy:**
 
-  * Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-  * Must have peer review policy for all change requests (e.g. require one or more reviewer)
-  * Must have Continuous Integration (CI) policy for all change requests
-  * Must have documentation policy for all change requests
-  * [ROS Core]:
+   #. Must have a version policy (e.g. ``semver``)
+   #. Must be at a stable version (e.g. for ``semver`` that means have a version >= 1.0.0)
+   #. Must have a strictly declared public API
+   #. Must have a policy for API stability
+   #. Must have a policy for ABI stability
+   #. Must have a policy that keeps API and ABI stability within a released ROS Distribution
 
-    * All changes will go through a pull request
-    * All pull requests will require at least one reviewer who did not author the pr (package may choose to increase this number)
-    * All pull requests will be tested via CI, and on all tier 1 platforms (if applicable)
-    * Any required changes to documentation (API documentation, feature documentation, release notes, etc.) must be proposed before merging related changes
+#. **Change Control Process:**
 
-* Documentation:
+   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have `Developer Certificate of Origin (DCO) <https://developercertificate.org/>`_ on pull requests
+   #. Must have peer review policy for all change requests (e.g. require one or more reviewer)
+   #. Must have Continuous Integration (CI) policy for all change requests
+   #. Must have documentation policy for all change requests
 
-  * Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
-  * Must have documentation for each item in the public API (e.g. functions, classes, etc.)
-  * Must have a declared license or set of licenses
-  * Must have a copyright statement in each source file
-  * Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+.. DCO only in level 1?
 
-    * Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it
-    * Must register with a centralized list of 'Level 1' packages, if one exists, to allow for peer review of the claim
+#. **Documentation:**
 
-  * [ROS Core]:
+   #. Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
+   #. Must have documentation for each item in the public API (e.g. functions, classes, etc.)
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+   #. Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
 
-    * Must have automated checks for copyright statements and licenses
-    * Must use the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
+      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
+      #. *Must register with a centralized list of 'Level 1' packages, if one exists, to allow for peer review of the claim*
 
-* Testing:
+#. **Testing:**
 
-  * Must have system tests which cover all items in the "feature" documentation
-  * Must have system, integration, and/or unit tests which cover all of the public API
-  * Code coverage:
+   #. Must have system tests which cover all items in the "feature" documentation
+   #. Must have system, integration, and/or unit tests which cover all of the public API
+   #. Code coverage:
 
-    * Must have code coverage tracking for the package
-    * Must have and enforce a code coverage policy for new changes
-    * [ROS Core]:
+      #. *Must have code coverage tracking for the package*
+      #. *Must have and enforce a code coverage policy for new changes*
 
-      * Must provide line coverage
-      * Must achieve a line coverage above 95%
-      * May pick a lower percentage target with justification, but must document it prominently
-      * May provide branch coverage
-      * May exclude code from coverage (test code, debug code, etc.)
-      * Must require coverage to increase or stay the same before merging a change, but...
-      * May accept a change that decreases coverage with proper justification (e.g. deleting code that was previously covered can cause the percentage to drop)
+   #. Performance:
 
-  * Performance:
+      #. *Must have performance tests (exceptions allowed if they don't make sense to have)*
+      #. *Must have a performance regression policy (i.e. blocking either changes or releases on unexpected performance regressions)*
 
-    * Must have performance tests (exceptions allowed if they don't make sense to have)
-    * Must have a performance regression policy (i.e. blocking either changes or releases on unexpected performance regressions)
-    * [ROS Core]:
+   #. Linters and Static Analysis
 
-      * May have performance tests, strongly recommended, but for some packages it doesn't make sense
-      * If there are performance tests, must choose to either check each change or before each release or both
-      * If there are performance tests, must require justification for merging a change or making a release that lowers performance
+      #. *Must have a code style and enforce it.*
+      #. *Must use static analysis tools where applicable.*
 
-  * Linters and Static Analysis
+#. **Dependencies:**
 
-    * Must have a code style and enforce it.
-    * Must use static analysis tools where applicable.
-    * [ROS Core]:
+   #. Must not have direct runtime "ROS" dependencies which are not 'Level 1' dependencies, but...
+   #. May have optional direct runtime "ROS" dependencies which are not 'Level 1', e.g. tracing or debugging features that can be disabled
+   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 1' package in terms of quality
 
-      * Must use ROS code style and use linters from ``ament_lint_common`` to enforce it
-      * Must use all linters/static analysis that are part of ``ament_lint_common``
+#. **Platform Support:**
 
-* Dependencies:
-
-  * Must not have direct runtime "ROS" dependencies which are not 'Level 1' dependencies, but...
-  * May have optional direct runtime "ROS" dependencies which are not 'Level 1', e.g. tracing or debugging features that can be disabled
-  * Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 1' package in terms of quality
-
-* Platform Support:
-
-  * Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 If the above points are satisfied then a package can be considered 'Level 1'.
-Below are some details on the above points.
+Refer to the detailed description of the requirements in the Rationale section below for more information.
+
+Quality Level 2
+^^^^^^^^^^^^^^^
+
+.. would it make more sense to have levels 2+ just say what's different from level 1? try that
+
+These are packages which need to be solidly developed and might be used in production environments, but are not strictly required, or are commonly replaced by custom solutions.
+This can also include packages which are not yet up to 'Level 1' but intend to be in the future.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 2' package:
+
+#. **Version Policy:**
+
+   #. The same as 'Level 1' packages
+
+#. **Change Control Process:**
+
+   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have Continuous Integration (CI) policy for all change requests
+
+#. **Documentation:**
+
+   #. Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+   #. Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+
+      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
+      #. *Must register with a centralized list of 'Level 2' packages, if one exists, to allow for peer review of the claim*
+
+#. **Testing:**
+
+   #. Must have system tests which cover all items in the "feature" documentation
+   #. Code coverage:
+
+      #. *Must have code coverage tracking for the package*
+
+   #. Linters and Static Analysis
+
+      #. *Must have a code style and enforce it.*
+      #. *Must use static analysis tools where applicable.*
+
+#. **Dependencies:**
+
+   #. Must not have direct runtime "ROS" dependencies which are not 'Level 2' dependencies, but...
+   #. May have optional direct runtime "ROS" dependencies which are not 'Level 2', e.g. tracing or debugging features that can be disabled
+   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 2' package in terms of quality
+
+#. **Platform Support:**
+
+   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+If the above points are satisfied then a package can be considered 'Level 2'.
+Refer to the detailed description of the requirements in the Rationale section below for more information.
+
+Quality Level 3
+^^^^^^^^^^^^^^^
+
+These are packages which are useful for development purposes or introspection, but are not recommended for use in embedded products or mission critical scenarios.
+These packages are more lax on documentation, testing, and scope of public API's in order to make development time lower or foster addition of new features.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 3' package:
+
+#. **Version Policy:**
+
+   #. The same as 'Level 1' packages, except:
+
+      #. *No public API needs to be explicitly declared, though this can make it harder to maintain API and ABI stability*
+      #. *No requirement to keep API/ABI stability within a stable ROS release, but it is recommended still*
+
+#. **Change Control Process:**
+
+   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have Continuous Integration (CI) policy for all change requests
+
+#. **Testing:**
+
+   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
+
+#. **Documentation:**
+
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+   #. May have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+
+      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
+      #. *May register with a centralized list of 'Level 3' packages, if one exists, to allow for peer review of the claim*
+
+#. **Dependencies:**
+
+   #. May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should be documented
+
+#. **Platform Support:**
+
+   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+If the above points are satisfied then a package can be considered 'Level 3'.
+Refer to the detailed description of the requirements in the Rationale section below for more information.
+
+Quality Level 4
+^^^^^^^^^^^^^^^
+
+These are demos, tutorials, or experiments.
+They don't have strict requirements, but are not excluded from having good documentation or tests.
+For example, this might be a tutorial package which is not intended for reuse but has excellent documentation because it serves primarily as an example to others.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 4' package:
+
+#. **Version Policy:**
+
+   #. No requirements, but having a policy is still recommended (e.g. ``semver``), even if the version is not yet stable (e.g. >= 1.0.0 for ``semver``)
+
+#. Change Control Process:
+
+   #. No explicit change control process required, but still recommended
+
+#. **Documentation:**
+
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+
+#. **Testing:**
+
+   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
+
+#. **Dependencies:**
+
+   #. No restrictions
+
+#. **Platform Support:**
+
+   #. May support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+Any package that does not claim to be 'Level 3' or higher is automatically 'Level 4'.
+Refer to the detailed description of the requirements in the Rationale section below for more information.
+
+Quality Level 5
+^^^^^^^^^^^^^^^
+
+Packages in this category cannot even meet the simple 'Level 4' requirements, and for that reason should not be used.
+All packages should have at least a declared license or set of licenses and should include copyright statements in each file.
+
+Repository Organization
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Since these categories are applied on a per package basis, and since there may be more than one package per source repository, it's recommended that the strictest set of policies apply to the whole repository.
+This is recommended rather than trying to mix processes depending on which packages are changed in a given change request (pull request or merge request, etc.).
+If this is too onerous, then it's recommended to split lower quality packages out into a separate repository.
+
+Rationale
+=========
+
+.. might move this back to specification section, remove rationale section
+
+.. also, there's no explanation for change control process. might be unnecessary but looks inconsistent
 
 Version Policy
-""""""""""""""
+^^^^^^^^^^^^^^
 
 The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
 We recommend the use of ``semver`` as it covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community broadly.
@@ -177,13 +321,13 @@ Additionally, specifically for the ROS ecosystem, the policy should state that A
 For ``semver``, this means only patch and minor increases only into an existing ROS distribution.
 
 Public API
-""""""""""
+~~~~~~~~~~
 
-The package should also state what the public API includes, and/or state what parts of the API are excluded intentionally.
+The package documentation should state what the public API includes, and/or state what parts of the API are excluded intentionally.
 
-For C++, it's somewhat obvious that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
+For C++, it's assumed that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
 For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
-Changes to these excluded API's, especially something like a "detail" namespace, should still not break API or ABI for other public API's indirectly.
+Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
 
 For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
 One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
@@ -191,91 +335,18 @@ One easy thing to do is to say all of the API is public and therefore API stable
 There are also other, non-API, things which should be considered and optionally documented as part of the "stable interface" of the package.
 This includes, but isn't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
 
-For yet other languages the details will be different, but the important thing is that the public API be obviously documented, and that the public API adheres to an API and ABI stability as described in the version policy, and that they are documented and tested.
+For other languages the details will be different, but the important thing is that the public API be obviously documented, and the public API adheres to a documented and tested API and ABI stability policy, as described in the version policy.
 
 Feature Documentation
-"""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^
 
 For each feature provided by the public API of the package, or by a tool in the package, there must be corresponding user documentation.
 The term "feature", and the scope of the documentation, is intentionally vague because it's difficult to quantitatively measure this metric.
 However, the spirit of this requirement is that, for a 'Level 1' quality package, all of the things a user might do with the package needs at least basic documentation or a snippet of code as an example on how to use it.
 The `roscpp Overview <https://wiki.ros.org/roscpp/Overview>`_ from the ROS 1 wiki is a good example of this kind of documentation.
 
-Feature Testing and Code Coverage Policy
-""""""""""""""""""""""""""""""""""""""""
-
-This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
-The policy may be influenced by factors like:
-
-- what programming languages are being used, and whether or not there are multiple languages in use
-- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
-- what strategy is preferred for dealing with difficult to reach statements/branches
-
-This StackOverflow question is a good summary of the issues:
-
-https://stackoverflow.com/questions/90002/what-is-a-reasonable-code-coverage-for-unit-tests-and-why
-
-In particular, this answer does a good job of summarizing the issue:
-
-https://stackoverflow.com/a/34698711/671658
-
-Importantly, this answer points out that tracking and enforcing code coverage statistics is strictly empirical (rather than theoretical) and that there are different reasons for using them.
-Among those reasons listed is "To satisfy stakeholders", which is the main goal of requiring a code coverage policy for these high quality packages.
-It is summarized nicely:
-
-    For many projects, there are various actors who have an interest in software quality who may not be involved in the day-to-day development of the software (managers, technical leads, etc.)
-    Saying "we're going to write all the tests we really need" is not convincing:
-    They either need to trust entirely, or verify with ongoing close oversight (assuming they even have the technical understanding to do so.)
-    Providing measurable standards and explaining how they reasonably approximate actual goals is better.
-
-The other two reasons "To normalize team behavior" and "To keep yourself honest" are nice reasons to have code coverage goals, but are out of scope for this document.
-
-The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
-This at least gives you and your stakeholders some confidence that all feature have basic tests.
-Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
-
-Performance Testing
-"""""""""""""""""""
-
-There are some cases where performance testing does not make sense to have.
-For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
-
-However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent new versions of the package to be considerably slower without cause.
-Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or when unavoidable (e.g. fixing a bug required more resources to be safe) explain why the regression has occurred in the memorandum of the change request that introduced it.
-
-Dependencies
-""""""""""""
-
-Each package should examine their direct runtime dependencies for their quality levels.
-Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
-
-An example of this would be build or "build tool" dependencies, which are only used during build time and do not impact the runtime quality of the package.
-This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also impact the quality of the runtime product directly.
-This would include, for another example, something like CMake, which in most ways does not impact the quality of the product.
-
-There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they impact the package.
-However, the point is to require the maintainers of the package to examine each dependency, justify why they do or do not impact the quality, and document that so that peer reviewers and consumers of the package can make their own evaluation.
-
-Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
-
-Dependencies which are not other "ROS" packages should be individually examined for quality.
-You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
-In either case, for each direct "non-ROS" dependency your "quality declaration" should include a justification as to why it is acceptable to depend on this software and still claim your package's level of quality.
-This may simply be text justification, or it may link to other analysis or discussions had by community members rationalizing the choice.
-The important point is that each dependency is considered, justified, and that the justification is documented, so that users of the package can read the justification and decide for themselves if it is acceptable or not.
-
-Any important caveats or justified exceptions for your dependencies should be mentioned (or referenced) in your own package's "quality declaration" document.
-
-For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'level 1' quality standard, then your package's "quality declaration" document should mention this as well.
-Perhaps just saying that one of your dependencies, ``rclcpp``, has some caveats and then link to ``rclcpp``'s own "quality declaration".
-
-In this way, caveats and justifications that may be important for peer reviewers and consumers of your package to understand can "bubble up" from any part of the system.
-
-The goal here is for the maintainer of a package to "make the case" to potential users or stakeholders that their dependencies are at least as high quality as the package in question, and to make a best effort attempt to make them aware of any issues or caveats.
-It's up to those users and stakeholders to evaluate that justification and to look at the dependencies themselves as well.
-
-Claiming a Quality Level and Documenting Package Policies
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Quality Declaration and Claim
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each package claiming a quality level should have a "quality declaration" documented somewhere.
 This declaration should include a claimed quality level and then should have a section for each of the requirements in that claimed quality level justifying how the package meets each of those requirements.
@@ -291,222 +362,134 @@ There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 
 These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
 This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
 
-Quality Level 2
-^^^^^^^^^^^^^^^
+Feature Testing and Code Coverage Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These are packages which need to be solidly developed and might be used in production environments, but are not strictly required, or are commonly replaced by custom solutions.
-This can also include packages which are not yet up to 'Level 1' but intend to be in the future.
+This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
+The policy may be influenced by factors like:
 
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
+- what programming languages are being used, and whether or not there are multiple languages in use
+- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
+- what strategy is preferred for dealing with difficult to reach statements/branches
 
-*Note: bullets below that start with [ROS Core], will be the prescription for what we do in the core packages in order to meet the associated requirements*
+Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
+Among those reasons is satisfying stakeholders [2]_, which is this REP's main goal for requiring a code coverage policy for high quality packages.
+A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
 
-Requirements to be considered a 'Level 2' package:
+The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
+This at least gives you and your stakeholders some confidence that all feature have basic tests.
+Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
 
-* Version Policy:
+Performance Testing
+^^^^^^^^^^^^^^^^^^^
 
-  * The same as 'Level 1' packages
+There are some cases where performance testing does not make sense to have.
+For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
 
-* Change Control Process:
+However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent unintended performance degradation.
+Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
 
-  * Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-  * Must have Continuous Integration (CI) policy for all change requests
-  * [ROS Core]:
+Dependencies
+^^^^^^^^^^^^
 
-    * All changes will go through a pull request
-    * All pull requests will be tested via CI
+Each package should examine their direct runtime dependencies for their quality levels.
+Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
 
-* Documentation:
+An example of this would be build or "build tool" dependencies, which are only used during build time and do not affect the runtime quality of the package.
+This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also affect the quality of the runtime product directly.
+This would include, for another example, something like CMake, which in most ways does not affect the quality of the product.
 
-  * Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
-  * Must have a declared license or set of licenses
-  * Must have a copyright statement in each source file
-  * Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they affect the quality of a package.
+However, the point is to require the maintainers of the package to examine each dependency, justify why they do or do not affect quality, and document that so that peer reviewers and consumers of the package can make their own evaluation.
 
-    * Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it
-    * Must register with a centralized list of 'Level 2' packages, if one exists, to allow for peer review of the claim
+Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
 
-  * [ROS Core]:
+Dependencies which are not other "ROS" packages should be individually examined for quality.
+You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
+In either case, for each direct "non-ROS" dependency your "quality declaration" should include a justification as to why it is acceptable to depend on this software and still claim your package's level of quality.
+This may simply be text justification, or it may link to other analysis or discussions had by community members rationalizing the choice.
+The important point is that each dependency is considered, justified, and that the justification is documented, so that users of the package can read the justification and decide for themselves if it is acceptable or not.
 
-    * Must have automated checks for copyright statements and licenses
-    * Must use the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
+Any important caveats or justified exceptions for your dependencies should be mentioned (or referenced) in your own package's "quality declaration" document.
 
-* Testing:
+For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'Level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'Level 1' quality standard, then your package's "quality declaration" document should mention this as well.
+Perhaps just saying that one of your dependencies, ``rclcpp``, has some caveats and then link to ``rclcpp``'s own "quality declaration".
 
-  * Must have system tests which cover all items in the "feature" documentation
-  * Code coverage:
+In this way, caveats and justifications that may be important for peer reviewers and consumers of your package to understand can "bubble up" from any part of the system.
 
-    * Must have code coverage tracking for the package
-    * [ROS Core]:
-
-      * Must provide line coverage statistics
-      * May provide branch coverage
-      * May exclude code from coverage (test code, debug code, etc.)
-
-  * Linters and Static Analysis
-
-    * Must have a code style and enforce it.
-    * Must use static analysis tools where applicable.
-    * [ROS Core]:
-
-      * Must use ROS code style and use linters from ``ament_lint_common`` to enforce it
-      * Must use all linters/static analysis that are part of ``ament_lint_common``
-
-* Dependencies:
-
-  * Must not have direct runtime "ROS" dependencies which are not 'Level 2' dependencies, but...
-  * May have optional direct runtime "ROS" dependencies which are not 'Level 2', e.g. tracing or debugging features that can be disabled
-  * Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 2' package in terms of quality
-
-* Platform Support:
-
-  * Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-If the above points are satisfied then a package can be considered 'Level 2'.
-Refer to the detailed description of the requirements in the Quality Level 1 section above for more information.
-
-Quality Level 3
-^^^^^^^^^^^^^^^
-
-These are packages which are useful for development purposes or introspection, but are not recommended for use in embedded products or mission critical scenarios.
-These packages are more lax on documentation, testing, and scope of public API's in order to make development time lower or foster addition of new features.
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-*Note: bullets below that start with [ROS Core], will be the prescription for what we do in the core packages in order to meet the associated requirements*
-
-Requirements to be considered a 'Level 3' package:
-
-* Version Policy:
-
-  * The same as 'Level 1' packages, except:
-
-    * No public API needs to be explicitly declared, though this can make it harder to maintain API and ABI stability
-    * No requirement to keep API/ABI stability within a stable ROS release, but it is recommended still
-
-* Change Control Process:
-
-  * Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-  * Must have Continuous Integration (CI) policy for all change requests
-  * [ROS Core]:
-
-    * All changes will go through a pull request
-    * All pull requests will be tested via CI
-
-* Documentation:
-
-  * Must have a declared license or set of licenses
-  * Must have a copyright statement in each source file
-  * May have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
-
-    * Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it
-    * May register with a centralized list of 'Level 3' packages, if one exists, to allow for peer review of the claim
-
-  * [ROS Core]:
-
-    * Must have automated checks for copyright statements and licenses
-    * Must use the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
-
-* Testing:
-
-  * No explicit testing requirements, though covering some if not all of the features with tests is recommended
-
-* Dependencies:
-
-  * May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should be documented
-
-* Platform Support:
-
-  * Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-If the above points are satisfied then a package can be considered 'Level 3'.
-Refer to the detailed description of the requirements in the Quality Level 1 section above for more information.
-
-Quality Level 4
-^^^^^^^^^^^^^^^
-
-These are demos, tutorials, or experiments.
-They don't have strict requirements, but are not excluded from having good documentation or tests.
-For example, this might be a tutorial package which is not intended for reuse but has excellent documentation because it serves primarily as an example to others.
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-*Note: bullets below that start with [ROS Core], will be the prescription for what we do in the core packages in order to meet the associated requirements*
-
-Requirements to be considered a 'Level 4' package:
-
-* Version Policy:
-
-  * No requirements, but having a policy is still recommended (e.g. ``semver``), even if the version is not yet stable (e.g. >= 1.0.0 for ``semver``)
-
-* Change Control Process:
-
-  * No explicit change control process required, but still recommended
-
-* Documentation:
-
-  * Must have a declared license or set of licenses
-  * Must have a copyright statement in each source file
-  * [ROS Core]:
-
-    * Must have automated checks for copyright statements and licenses
-    * Must use the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
-
-* Testing:
-
-  * No explicit testing requirements, though covering some if not all of the features with tests is recommended
-
-* Dependencies:
-
-  * No restrictions
-
-* Platform Support:
-
-  * May support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-Any package that does not claim to be 'Level 3' or higher is automatically 'Level 4'.
-Refer to the detailed description of the requirements in the Quality Level 1 section above for more information.
-
-Quality Level 5
-^^^^^^^^^^^^^^^
-
-Packages in this category simply do not meet even the 'Level 4' requirements, and for that reason should not be used.
-The rationale being that all packages should have at least a declare license or licenses and should include copyright statements in each file.
-
-Repository Organization
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Since these categories are applied on a per package basis, and since there may be more than one package per source repository, it's recommended that the strictest set of policies apply to the whole repository.
-This is recommended, rather than trying to mix processes depending on which packages are changed in a given change request (pull request or merge request, etc.).
-If this is too onerous, then it's recommended to split lower quality packages out into a separate repository.
-
-
-Motivation
-==========
-
-TBD
-
-
-Rationale
-=========
-
-TBD
+The goal here is for the maintainer of a package to "make the case" to potential users or stakeholders that their dependencies are at least as high quality as the package in question, and to make a best effort attempt to make them aware of any issues or caveats.
+It's up to those users and stakeholders to evaluate that justification and to look at the dependencies themselves as well.
 
 
 Backwards Compatibility
 =======================
 
-Since there are no preceeding standards in this space, at least in the ROS community, of which we are aware, there are no backwards compatibility concerns.
+.. this entire section can be removed if there are in fact no backwards compatibility concerns
+
+Since there are no preceding standards in this space, at least in the ROS community, of which we are aware, there are no backwards compatibility concerns.
 
 
 Reference Implementation
 ========================
 
-TBD: Link to "ROS Core" perscription for how to actually achieve each quality level.
+The `ROS 2 Developer Guide <https://index.ros.org/doc/ros2/Contributing/Developer-Guide/>`_ describes the policies we implement to achieve Quality Level 1 for ROS Core packages.
 
+The `rcutils package's quality declaration <https://github.com/ros2/rcutils/pull/202/files>`_ is one example of the conditions of this REP in practice on a non-trivial package.
+
+.. update link when that draft is merged
+
+Quality Declaration Template
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. possible location for the template. another option is having a folder for rep2004 and putting the file in there, and linking from the reference implementation section. some other reps have folders with images. might be "cleaner" and still technically "self-contained". also easier for others to reference or copy.
+
+.. code-block:: markdown
+
+  This document is a declaration of software quality for the `<package name>` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+  # `<package name>` Quality Declaration
+
+  The package `<package name>` claims to be in the **Quality Level N** category.
+
+  Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level N in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+  ## Version Policy
+
+  ### Version Scheme
+
+  ### API Stability Within a Released ROS Distribution
+
+  ### ABI Stability Within a Released ROS Distribution
+
+  ### Public API Declaration
+
+  ## Change Control Process
+
+  ## Documentation
+
+  ### Feature Documentation
+
+  ### Public API Documentation
+
+  ### License
+
+  ### Copyright Statements
+
+  ## Testing
+
+  ### Feature Testing
+
+  ### Public API Testing
+
+  ### Coverage
+
+  ### Performance
+
+  ### Linters and Static Analysis
+
+  ## Dependencies
+
+  ## Platform Support
 
 References and Footnotes
 ========================
@@ -514,6 +497,8 @@ References and Footnotes
 .. [1] Initial discussions about this REP:
    https://github.com/ros2/ros2_documentation/pull/460
 
+.. [2] What is a reasonable code coverage % for unit tests (and why)?
+   https://stackoverflow.com/a/34698711/671658
 
 Copyright
 =========

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -106,7 +106,7 @@ Requirements to be considered a 'Level 1' package:
    #. Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
 
       #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
-      #. *Must register with a centralized list of 'Level 1' packages, if one exists, to allow for peer review of the claim*
+      #. *Must register with a centralized list of 'Level N' packages, if one exists, to allow for peer review of the claim*
 
 #. **Testing:**
 
@@ -129,9 +129,9 @@ Requirements to be considered a 'Level 1' package:
 
 #. **Dependencies:**
 
-   #. Must not have direct runtime "ROS" dependencies which are not 'Level 1' dependencies, but...
-   #. May have optional direct runtime "ROS" dependencies which are not 'Level 1', e.g. tracing or debugging features that can be disabled
-   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 1' package in terms of quality
+   #. Must not have direct runtime "ROS" dependencies which are not at the same level as the package in question ('Level N'), but...
+   #. May have optional direct runtime "ROS" dependencies which are not 'Level N', e.g. tracing or debugging features that can be disabled
+   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level N' package in terms of quality
 
 #. **Platform Support:**
 
@@ -360,7 +360,7 @@ Requirements to be considered a 'Level 4' package:
 
    #. No requirements, but having a policy is still recommended (e.g. ``semver``), even if the version is not yet stable (e.g. >= 1.0.0 for ``semver``)
 
-#. Change Control Process:
+#. **Change Control Process:**
 
    #. No explicit change control process required, but still recommended
 
@@ -389,6 +389,207 @@ Quality Level 5
 
 Packages in this category cannot even meet the simple 'Level 4' requirements, and for that reason should not be used.
 All packages should have at least a declared license or set of licenses and should include copyright statements in each file.
+
+Quality Level Comparison Chart
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+✓ = required
+
+● = recommended
+
+.. list-table:: Quality Levels
+    :widths: 5 10 10 10 10 10
+    :header-rows: 1
+    :stub-columns: 1
+    :align: left
+
+
+    * -
+      - Level 1
+      - Level 2
+      - Level 3
+      - Level 4
+      - Level 5
+    * - 1.i
+      - ✓
+      - ✓
+      - ✓
+      - ●
+      -
+    * - 1.ii
+      - ✓
+      - ✓
+      - ✓
+      -
+      -
+    * - 1.iii
+      - ✓
+      - ✓
+      - ●
+      -
+      -
+    * - 1.iv
+      - ✓
+      - ✓
+      - ✓
+      -
+      -
+    * - 1.v
+      - ✓
+      - ✓
+      - ✓
+      -
+      -
+    * - 1.vi
+      - ✓
+      - ✓
+      - ●
+      -
+      -
+    * - 2.i
+      - ✓
+      - ✓
+      - ✓
+      - ●
+      -
+    * - 2.ii
+      - ✓
+      -
+      -
+      -
+      -
+    * - 2.iii
+      - ✓
+      -
+      -
+      -
+      -
+    * - 2.iv
+      - ✓
+      - ✓
+      - ✓
+      -
+      -
+    * - 2.v
+      - ✓
+      -
+      -
+      -
+      -
+    * - 3.i
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 3.ii
+      - ✓
+      -
+      -
+      -
+      -
+    * - 3.iii
+      - ✓
+      - ✓
+      - ✓
+      - ✓
+      -
+    * - 3.iv
+      - ✓
+      - ✓
+      - ✓
+      - ✓
+      -
+    * - 3.v
+      - ✓
+      - ✓
+      - ●
+      -
+      -
+    * - 3.v.a
+      - ✓
+      - ✓
+      - ●
+      -
+      -
+    * - 3.v.b
+      - ✓
+      - ✓
+      - ●
+      -
+      -
+    * - 4.i
+      - ✓
+      - ✓
+      - ●
+      - ●
+      -
+    * - 4.ii
+      - ✓
+      -
+      -
+      -
+      -
+    * - 4.iii.a
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 4.iii.b
+      - ✓
+      -
+      -
+      -
+      -
+    * - 4.iv.a
+      - ✓
+      -
+      -
+      -
+      -
+    * - 4.iv.b
+      - ✓
+      -
+      -
+      -
+      -
+    * - 4.v.a
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 4.v.b
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 5.i
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 5.ii
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 5.iii
+      - ✓
+      - ✓
+      -
+      -
+      -
+    * - 6.i
+      - ✓
+      - ✓
+      - ✓
+      - ●
+      -
 
 Repository Organization
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -138,257 +138,7 @@ Requirements to be considered a 'Level 1' package:
    #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
 
 If the above points are satisfied then a package can be considered 'Level 1'.
-Refer to the detailed description of the requirements below for more information.
-
-Version Policy
-~~~~~~~~~~~~~~
-
-The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
-For example, ``semver`` covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community.
-
-The policy should link changes to API and ABI to the version scheme.
-
-For the ROS ecosystem, the version policy needs to state that API and ABI will be maintained within a stable ROS distribution.
-Following ``semver``, this means only patch and minor increases only into an existing ROS distribution.
-
-Public API
-""""""""""
-
-The package documentation should state what the public API includes, and/or state what parts of the API are excluded intentionally.
-
-For C++, it's assumed that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
-For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
-Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
-
-For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
-One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
-
-There are also other, non-API, things which should be considered and documented as part of the "stable interface" of the package.
-These could include, but aren't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
-
-For other languages the details will be different, but the important thing is that the public API be obviously documented, and the public API adheres to a documented and tested API and ABI stability policy, as described in the version policy.
-
-Feature Documentation
-~~~~~~~~~~~~~~~~~~~~~
-
-For each feature provided by the public API of the package, or by a tool in the package, there must be corresponding user documentation.
-The term "feature", and the scope of the documentation, is intentionally vague because it's difficult to quantitatively measure this metric.
-In general, for a 'Level 1' quality package, all of the things a user might do with the package need at least basic documentation or a snippet of code as an example on how to use it.
-The `roscpp Overview <https://wiki.ros.org/roscpp/Overview>`_ from the ROS 1 wiki is a good example of this kind of documentation.
-
-Quality Declaration and Claim
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Each package claiming a quality level should include a "quality declaration" document.
-This declaration should include a claimed quality level and then should have a section for each of the requirements in that claimed quality level justifying how the package meets each of those requirements.
-
-Sometimes the justification will be a link to a policy documented in the package itself or it may link to a common policy used by a group of packages.
-If there is additional evidence that these policies are being followed, that should be included as well, e.g. a link to the coverage statistics for the package to show that coverage is being tracked and maintained.
-Other times, justification will be an explanation as to why a requirement was not met or does not apply, e.g. if performance tests do not make sense for the package in question, it should be satisfactorily explained.
-
-There is no enforcement or checking of these claims, but instead it's just sufficient to present this information to potential users.
-If the users feel that the justifications are insufficient or incorrect, they can open issues against the repository and resolve it with the maintainers.
-
-There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
-These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
-This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
-
-Feature Testing and Code Coverage Policy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
-The policy may be influenced by factors like:
-
-- what programming languages are being used, and whether or not there are multiple languages in use
-- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
-- what strategy is preferred for dealing with difficult to reach statements/branches
-
-Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
-Among those reasons is satisfying stakeholders [2]_, which is main goal of requiring a code coverage policy for high quality packages.
-A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
-
-The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
-This at least gives you and your stakeholders some confidence that all feature have basic tests.
-Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
-
-Performance Testing
-~~~~~~~~~~~~~~~~~~~
-
-There are some cases where performance testing does not make sense to have.
-For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
-
-However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent unintended performance degradation.
-Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
-
-Dependencies
-~~~~~~~~~~~~
-
-Each package should examine the quality levels of their direct runtime dependencies.
-Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
-
-An example of an exception would be build or "build tool" dependencies, which are only used during build time and do not affect the runtime quality of the package.
-This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also affect the quality of the runtime product directly.
-Conversely, this would include something like CMake, which in most ways does not affect the quality of the product.
-
-Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
-Dependencies which are not other "ROS" packages should be individually examined for quality.
-You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
-The argument could be text justification, or it could link to other analyses or discussions had by community members rationalizing the choice.
-
-For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'Level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'Level 1' quality standard, then your package's "quality declaration" document should mention this as well.
-This could be accomplished simply by saying that one of your dependencies, ``rclcpp``, has some caveats and then linking to ``rclcpp``'s own "quality declaration".
-
-There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they affect the quality of a package.
-The goal is for the maintainers of a package to "make the case" that their dependencies are at least as high quality as the package in question.
-They should examine each dependency, and document any important caveats or justified exceptions in the package's "quality declaration" document so peer reviewers and consumers of the package can make their own evaluations.
-
-Quality Level 2
-^^^^^^^^^^^^^^^
-
-These are packages which need to be solidly developed and might be used in production environments, but are not strictly required, or are commonly replaced by custom solutions.
-This can also include packages which are not yet up to 'Level 1' but intend to be in the future.
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-Requirements to be considered a 'Level 2' package:
-
-#. **Version Policy:**
-
-   #. The same as 'Level 1' packages
-
-#. **Change Control Process:**
-
-   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-   #. Must have Continuous Integration (CI) policy for all change requests
-
-#. **Documentation:**
-
-   #. Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
-   #. Must have a declared license or set of licenses
-   #. Must have a copyright statement in each source file
-   #. Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
-
-      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
-      #. *Must register with a centralized list of 'Level 2' packages, if one exists, to allow for peer review of the claim*
-
-#. **Testing:**
-
-   #. Must have system tests which cover all items in the "feature" documentation
-   #. Code coverage:
-
-      #. *Must have code coverage tracking for the package*
-
-   #. Linters and Static Analysis
-
-      #. *Must have a code style and enforce it.*
-      #. *Must use static analysis tools where applicable.*
-
-#. **Dependencies:**
-
-   #. Must not have direct runtime "ROS" dependencies which are not 'Level 2' dependencies, but...
-   #. May have optional direct runtime "ROS" dependencies which are not 'Level 2', e.g. tracing or debugging features that can be disabled
-   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 2' package in terms of quality
-
-#. **Platform Support:**
-
-   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-If the above points are satisfied then a package can be considered 'Level 2'.
-Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
-
-Quality Level 3
-^^^^^^^^^^^^^^^
-
-These are packages which are useful for development purposes or introspection, but are not recommended for use in embedded products or mission critical scenarios.
-These packages are more lax on documentation, testing, and scope of public API's in order to make development time lower or foster addition of new features.
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-Requirements to be considered a 'Level 3' package:
-
-#. **Version Policy:**
-
-   #. The same as 'Level 1' packages, except:
-
-      #. *No public API needs to be explicitly declared, though this can make it harder to maintain API and ABI stability*
-      #. *No requirement to keep API/ABI stability within a stable ROS release, but it is recommended still*
-
-#. **Change Control Process:**
-
-   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
-   #. Must have Continuous Integration (CI) policy for all change requests
-
-#. **Documentation:**
-
-   #. Must have a declared license or set of licenses
-   #. Must have a copyright statement in each source file
-   #. May have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
-
-      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
-      #. *May register with a centralized list of 'Level 3' packages, if one exists, to allow for peer review of the claim*
-
-#. **Testing:**
-
-   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
-
-#. **Dependencies:**
-
-   #. May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should be documented
-
-#. **Platform Support:**
-
-   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-If the above points are satisfied then a package can be considered 'Level 3'.
-Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
-
-Quality Level 4
-^^^^^^^^^^^^^^^
-
-These are demos, tutorials, or experiments.
-They don't have strict requirements, but are not excluded from having good documentation or tests.
-For example, this might be a tutorial package which is not intended for reuse but has excellent documentation because it serves primarily as an example to others.
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-Requirements to be considered a 'Level 4' package:
-
-#. **Version Policy:**
-
-   #. No requirements, but having a policy is still recommended (e.g. ``semver``), even if the version is not yet stable (e.g. >= 1.0.0 for ``semver``)
-
-#. **Change Control Process:**
-
-   #. No explicit change control process required, but still recommended
-
-#. **Documentation:**
-
-   #. Must have a declared license or set of licenses
-   #. Must have a copyright statement in each source file
-
-#. **Testing:**
-
-   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
-
-#. **Dependencies:**
-
-   #. No restrictions
-
-#. **Platform Support:**
-
-   #. May support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
-
-Any package that does not claim to be 'Level 3' or higher is automatically 'Level 4'.
-Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
-
-Quality Level 5
-^^^^^^^^^^^^^^^
-
-Packages in this category cannot even meet the simple 'Level 4' requirements, and for that reason should not be used.
-All packages should have at least a declared license or set of licenses and should include copyright statements in each file.
+Refer to the detailed description of the requirements below the chart for more information.
 
 Quality Level Comparison Chart
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -590,6 +340,256 @@ Quality Level Comparison Chart
       - ✓
       - ●
       -
+
+Version Policy
+^^^^^^^^^^^^^^
+
+The most important thing is to have some version policy which developers may use to anticipate and understand changes to the version of the package.
+For example, ``semver`` covers all the important points that a version policy should cover, is well thought out, and is popular in the open source community.
+
+The policy should link changes to API and ABI to the version scheme.
+
+For the ROS ecosystem, the version policy needs to state that API and ABI will be maintained within a stable ROS distribution.
+Following ``semver``, this means only patch and minor increases only into an existing ROS distribution.
+
+Public API
+~~~~~~~~~~
+
+The package documentation should state what the public API includes, and/or state what parts of the API are excluded intentionally.
+
+For C++, it's assumed that all installed headers are part of the public API, but it's acceptable to have parts of the accessible API not be stable.
+For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
+Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
+
+For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
+One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
+
+There are also other, non-API, things which should be considered and documented as part of the "stable interface" of the package.
+These could include, but aren't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
+
+For other languages the details will be different, but the important thing is that the public API be obviously documented, and the public API adheres to a documented and tested API and ABI stability policy, as described in the version policy.
+
+Feature Documentation
+^^^^^^^^^^^^^^^^^^^^^
+
+For each feature provided by the public API of the package, or by a tool in the package, there must be corresponding user documentation.
+The term "feature", and the scope of the documentation, is intentionally vague because it's difficult to quantitatively measure this metric.
+In general, for a 'Level 1' quality package, all of the things a user might do with the package need at least basic documentation or a snippet of code as an example on how to use it.
+The `roscpp Overview <https://wiki.ros.org/roscpp/Overview>`_ from the ROS 1 wiki is a good example of this kind of documentation.
+
+Quality Declaration and Claim
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each package claiming a quality level should include a "quality declaration" document.
+This declaration should include a claimed quality level and then should have a section for each of the requirements in that claimed quality level justifying how the package meets each of those requirements.
+
+Sometimes the justification will be a link to a policy documented in the package itself or it may link to a common policy used by a group of packages.
+If there is additional evidence that these policies are being followed, that should be included as well, e.g. a link to the coverage statistics for the package to show that coverage is being tracked and maintained.
+Other times, justification will be an explanation as to why a requirement was not met or does not apply, e.g. if performance tests do not make sense for the package in question, it should be satisfactorily explained.
+
+There is no enforcement or checking of these claims, but instead it's just sufficient to present this information to potential users.
+If the users feel that the justifications are insufficient or incorrect, they can open issues against the repository and resolve it with the maintainers.
+
+There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
+These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
+This document will not prescribe how or where these lists should be hosted, but one thought is that the list could live on the main ROS 2 documentation website.
+
+Feature Testing and Code Coverage Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This policy should aim for a "high" coverage standard, but the exact number and rules will vary depending on the package in question.
+The policy may be influenced by factors like:
+
+- what programming languages are being used, and whether or not there are multiple languages in use
+- what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
+- what strategy is preferred for dealing with difficult to reach statements/branches
+
+Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
+Among those reasons is satisfying stakeholders [2]_, which is main goal of requiring a code coverage policy for high quality packages.
+A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of doing so.
+
+The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
+This at least gives you and your stakeholders some confidence that all feature have basic tests.
+Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
+
+Performance Testing
+^^^^^^^^^^^^^^^^^^^
+
+There are some cases where performance testing does not make sense to have.
+For example, it may be a good idea to have performance tests for a code generator (like ``rosidl_generator_cpp``), but it is not strictly required since its performance does not affect a runtime production system, and so in that case the package could claim to be 'Level 1' without performance tests if properly justified in the "quality declaration".
+
+However, if performance is a reasonable concern for use in a production system, then there must be performance tests and they should be used in conjunction with a regression policy which aims to prevent unintended performance degradation.
+Note, the performance regression policy should not prevent regressions, but instead should aim to detect them and either address them directly, plan to address them in the future, or, when unavoidable (e.g. fixing a bug required more resources to be safe), explain why the regression has occurred in the memorandum of the change request that introduced it.
+
+Dependencies
+^^^^^^^^^^^^
+
+Each package should examine the quality levels of their direct runtime dependencies.
+Packages should not claim a quality level higher than their dependencies, unless it can be reasonably explained why they do not affect the quality of the package in question.
+
+An example of an exception would be build or "build tool" dependencies, which are only used during build time and do not affect the runtime quality of the package.
+This would not include, however, build dependencies which, for example, contribute only headers to a C++ library or a static library, as the quality of those headers or static library also affect the quality of the runtime product directly.
+Conversely, this would include something like CMake, which in most ways does not affect the quality of the product.
+
+Dependencies which are other "ROS" packages should have these quality standards applied to them and should meet or exceed the quality level claimed by the package in question.
+Dependencies which are not other "ROS" packages should be individually examined for quality.
+You may either try to apply the requirements for the quality levels described here, or you may wish to simply argue the quality without using these requirements as a ruler.
+The argument could be text justification, or it could link to other analyses or discussions had by community members rationalizing the choice.
+
+For example, if your package depends on ``rclcpp``, and ``rclcpp`` claims 'Level 1' quality with the caveat that this requires you use an rmw implementation that also meets the 'Level 1' quality standard, then your package's "quality declaration" document should mention this as well.
+This could be accomplished simply by saying that one of your dependencies, ``rclcpp``, has some caveats and then linking to ``rclcpp``'s own "quality declaration".
+
+There's obviously a lot of ambiguity in this area, as you could argue for or against a variety of dependencies and how they affect the quality of a package.
+The goal is for the maintainers of a package to "make the case" that their dependencies are at least as high quality as the package in question.
+They should examine each dependency, and document any important caveats or justified exceptions in the package's "quality declaration" document so peer reviewers and consumers of the package can make their own evaluations.
+
+Quality Level 2
+^^^^^^^^^^^^^^^
+
+These are packages which need to be solidly developed and might be used in production environments, but are not strictly required, or are commonly replaced by custom solutions.
+This can also include packages which are not yet up to 'Level 1' but intend to be in the future.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 2' package:
+
+#. **Version Policy:**
+
+   #. The same as 'Level 1' packages
+
+#. **Change Control Process:**
+
+   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have Continuous Integration (CI) policy for all change requests
+
+#. **Documentation:**
+
+   #. Must have documentation for each "feature" (e.g. for ``rclcpp``: create a node, publish a message, spin, etc.)
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+   #. Must have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+
+      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
+      #. *Must register with a centralized list of 'Level 2' packages, if one exists, to allow for peer review of the claim*
+
+#. **Testing:**
+
+   #. Must have system tests which cover all items in the "feature" documentation
+   #. Code coverage:
+
+      #. *Must have code coverage tracking for the package*
+
+   #. Linters and Static Analysis
+
+      #. *Must have a code style and enforce it.*
+      #. *Must use static analysis tools where applicable.*
+
+#. **Dependencies:**
+
+   #. Must not have direct runtime "ROS" dependencies which are not 'Level 2' dependencies, but...
+   #. May have optional direct runtime "ROS" dependencies which are not 'Level 2', e.g. tracing or debugging features that can be disabled
+   #. Must have justification for why each direct runtime "non-ROS" dependency is equivalent to a 'Level 2' package in terms of quality
+
+#. **Platform Support:**
+
+   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+If the above points are satisfied then a package can be considered 'Level 2'.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
+
+Quality Level 3
+^^^^^^^^^^^^^^^
+
+These are packages which are useful for development purposes or introspection, but are not recommended for use in embedded products or mission critical scenarios.
+These packages are more lax on documentation, testing, and scope of public API's in order to make development time lower or foster addition of new features.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 3' package:
+
+#. **Version Policy:**
+
+   #. The same as 'Level 1' packages, except:
+
+      #. *No public API needs to be explicitly declared, though this can make it harder to maintain API and ABI stability*
+      #. *No requirement to keep API/ABI stability within a stable ROS release, but it is recommended still*
+
+#. **Change Control Process:**
+
+   #. Must have all code changes occur through a change request (e.g. pull request, merge request, etc.)
+   #. Must have Continuous Integration (CI) policy for all change requests
+
+#. **Documentation:**
+
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+   #. May have a "quality declaration" document, which declares the quality level and justifies how the package meets each of the requirements
+
+      #. *Must have a section in the repository's ``README`` which contains the "quality declaration" or links to it*
+      #. *May register with a centralized list of 'Level 3' packages, if one exists, to allow for peer review of the claim*
+
+#. **Testing:**
+
+   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
+
+#. **Dependencies:**
+
+   #. May have direct runtime "ROS" dependencies which are not 'Level 3' dependencies, but they should be documented
+
+#. **Platform Support:**
+
+   #. Must support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+If the above points are satisfied then a package can be considered 'Level 3'.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
+
+Quality Level 4
+^^^^^^^^^^^^^^^
+
+These are demos, tutorials, or experiments.
+They don't have strict requirements, but are not excluded from having good documentation or tests.
+For example, this might be a tutorial package which is not intended for reuse but has excellent documentation because it serves primarily as an example to others.
+
+Package Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Requirements to be considered a 'Level 4' package:
+
+#. **Version Policy:**
+
+   #. No requirements, but having a policy is still recommended (e.g. ``semver``), even if the version is not yet stable (e.g. >= 1.0.0 for ``semver``)
+
+#. **Change Control Process:**
+
+   #. No explicit change control process required, but still recommended
+
+#. **Documentation:**
+
+   #. Must have a declared license or set of licenses
+   #. Must have a copyright statement in each source file
+
+#. **Testing:**
+
+   #. No explicit testing requirements, though covering some if not all of the features with tests is recommended
+
+#. **Dependencies:**
+
+   #. No restrictions
+
+#. **Platform Support:**
+
+   #. May support all tier 1 platforms for ROS 2, as defined in `REP-2000 <https://www.ros.org/reps/rep-2000.html#support-tiers>`_
+
+Any package that does not claim to be 'Level 3' or higher is automatically 'Level 4'.
+Refer to the detailed description of the requirements following the Quality Level 1 section above for more information.
+
+Quality Level 5
+^^^^^^^^^^^^^^^
+
+Packages in this category cannot even meet the simple 'Level 4' requirements, and for that reason should not be used.
+All packages should have at least a declared license or set of licenses and should include copyright statements in each file.
 
 Repository Organization
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/rep-2004.rst
+++ b/rep-2004.rst
@@ -13,7 +13,7 @@ Abstract
 
 This REP describes a set of categories meant to convey the quality or maturity of packages in the ROS ecosystem.
 Inclusion in a category, or quality level, is based on the policies to which a package adheres.
-The categories address version, change control, documentation, testing, and platform support policies.
+The categories address version, change control, documentation, testing, dependency and platform support policies.
 
 Motivation
 ==========
@@ -29,7 +29,7 @@ By providing these rough goals for package maintainers to strive towards, the ca
 Specification
 =============
 
-There are four quality levels described below, each roughly described as:
+There are four quality levels below, each roughly summarized as:
 
 * Quality Level 1:
 
@@ -66,14 +66,14 @@ These are the packages that remain as requirements for a basic ROS system to run
 
 Packages that would not normally fit this description can still be called 'Level 1'.
 If there is a need for a particular package in a reasonable production scenario, then that package should be considered for this category as well.
-However, packages which we consider essential to getting a robot up and running quickly, but perhaps provide a generic solution to a problem should probably not start out as 'Level 1' due to the high effort in getting a package to 'Level 1' and maintaining it there.
+However, packages which we consider essential to getting a robot up and running quickly, but perhaps provide a generic solution to a problem should probably not start out as 'Level 1' due to the high effort required to get a package to 'Level 1' and maintain it there.
 
 For example, packages which provide intra-process communication, inter-process communication, generated message runtime code, node lifecycle, etc. should probably all be considered for 'Level 1'.
 However, a package which provides pose estimation (like ``robot_pose_ekf``\ ) is a generic solution for something that most people need, but is often replaced with a domain specific solution in production, and therefore it should probably not start out as 'Level 1'.
-However, it may upgrade to it at a later date, if it proves to be a solution that people want to use in their products.
+Such a package may upgrade to 'Level 1' at a later date, if it proves to be a solution that people want to use in their products.
 
 Tools, like ``rostopic``\ , generally do not fall into this category either, but are not categorically excluded.
-For example, it may be the case the tool which launches and verifies a ROS graph (``ros2launch``\ ) may need to be considered 'Level 1' for use in production systems.
+For example, it may be the case that the tool which launches and verifies a ROS graph (``ros2launch``\ ) may need to be considered 'Level 1' for use in production systems.
 
 Package Requirements
 ~~~~~~~~~~~~~~~~~~~~
@@ -83,11 +83,11 @@ Requirements to be considered a 'Level 1' package:
 #. **Version Policy:**
 
    #. Must have a version policy (e.g. ``semver``)
-   #. Must be at a stable version (e.g. for ``semver`` that means have a version >= 1.0.0)
+   #. Must be at a stable version (e.g. for ``semver`` that means version >= 1.0.0)
    #. Must have a strictly declared public API
    #. Must have a policy for API stability
    #. Must have a policy for ABI stability
-   #. Must have a policy that keeps API and ABI stability within a released ROS Distribution
+   #. Must have a policy that keeps API and ABI stability within a released ROS distribution
 
 #. **Change Control Process:**
 
@@ -112,7 +112,7 @@ Requirements to be considered a 'Level 1' package:
 
    #. Must have system tests which cover all items in the "feature" documentation
    #. Must have system, integration, and/or unit tests which cover all of the public API
-   #. Code coverage:
+   #. Code Coverage:
 
       #. *Must have code coverage tracking for the package*
       #. *Must have and enforce a code coverage policy for new changes*
@@ -124,8 +124,8 @@ Requirements to be considered a 'Level 1' package:
 
    #. Linters and Static Analysis
 
-      #. *Must have a code style and enforce it.*
-      #. *Must use static analysis tools where applicable.*
+      #. *Must have a code style and enforce it*
+      #. *Must use static analysis tools where applicable*
 
 #. **Dependencies:**
 
@@ -143,7 +143,7 @@ Refer to the detailed description of the requirements below the chart for more i
 Quality Level Comparison Chart
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The chart below compares Quality Levels 1 through 4 relative to the Level 1 requirements' numbering scheme above.
+The chart below compares Quality Levels 1 through 5 relative to the 'Level 1' requirements' numbering scheme above.
 
 ✓ = required
 
@@ -325,9 +325,9 @@ The chart below compares Quality Levels 1 through 4 relative to the Level 1 requ
       -
       -
     * - 5.ii
-      - ✓
-      - ✓
-      -
+      - ●
+      - ●
+      - ●
       -
       -
     * - 5.iii
@@ -352,7 +352,7 @@ For example, ``semver`` covers all the important points that a version policy sh
 The version policy should link public API changes, which may also impact ABI, to changes in the version number.
 
 For the ROS ecosystem, the version policy needs to state that API and ABI will be maintained within a stable ROS distribution.
-Following ``semver``, this means only patch and minor increases only into an existing ROS distribution.
+Following ``semver``, this means only patch and minor increases are allowed into an existing ROS distribution.
 
 Public API
 ~~~~~~~~~~
@@ -363,8 +363,8 @@ For C++, it's assumed that all installed headers are part of the public API, but
 For example, having an "experimental" namespace or a "detail" namespace which does not adhere to the API and ABI stability rules is allowed, but they must be clearly documented as such.
 Changes to these excluded APIs, especially something like a "detail" namespace, should still not break API or ABI for other public APIs indirectly.
 
-For Python, it's more important to explicitly declare which parts of the API is public, because all modules are typically installed and accessible to users.
-One easy thing to do is to say all of the API is public and therefore API stable, but "impl" or "detail" namespaces can be used if needed, they just need to be clearly documented as not public and therefore not stable.
+For Python, it's more important to explicitly declare which parts of the API are public, because all modules are typically installed and accessible to users.
+One easy thing to do is to say all of the API is public and therefore API stable, but ``impl`` or ``detail`` namespaces can be used if needed, they just need to be clearly documented as "not public" and therefore not stable.
 
 There are also other, non-API, things which should be considered and documented as part of the "stable interface" of the package.
 These could include, but aren't limited to, message definitions, command line tools (arguments and output format), ROS names (topic, service, node, etc.), and behaviors of the applications.
@@ -394,7 +394,7 @@ If the users feel that the justifications are insufficient or incorrect, they ca
 
 There should be one or more communal lists of 'Level 1' (and maybe 'Level 2' or 'Level 3') quality level packages.
 These lists should be modified via change requests (maybe a text document in a repository) so that there can be peer review.
-This document will not prescribe how or where these lists should be hosted, but one possibility is an informational REP, continually updated and versioned with each new ROS distribution.
+This REP will not prescribe how or where these lists should be hosted, but one possibility is an informational REP, continually updated and versioned with each new ROS distribution.
 
 Feature Testing and Code Coverage Policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -404,15 +404,15 @@ The policy may be influenced by factors like:
 
 - what programming languages are being used, and whether or not there are multiple languages in use
 - what coverage information is available (statement vs. line vs. branch vs condition/path coverage)
-- what strategy is preferred for dealing with difficult to reach statements/branches
+- what strategy is preferred for dealing with difficult-to-reach statements/branches
 
 Tracking and enforcing code coverage statistics is strictly empirical and there are different reasons for using them.
 Among those reasons is satisfying stakeholders [2]_, which is the main goal of requiring a code coverage policy for high quality packages.
 A set of measurable standards and explanations of the goals they equate to is likely the most convincing method of proving to stakeholders that the package is properly tested.
 
 The general recommendation is to have at least line coverage and aim to achieve and maintain a high percentage of coverage (e.g. above 90%).
-This at least gives you and your stakeholders some confidence that all feature have basic tests.
-Any assurances beyond that would require branch coverage statistics and independent investigation of the tests and how they test the code.
+This at least gives you and your stakeholders some confidence that all features have basic tests.
+Any assurances beyond that would require branch coverage statistics and independent investigation of the tests.
 
 Performance Testing
 ^^^^^^^^^^^^^^^^^^^
@@ -479,14 +479,14 @@ Requirements to be considered a 'Level 2' package:
 #. **Testing:**
 
    #. Must have system tests which cover all items in the "feature" documentation
-   #. Code coverage:
+   #. Code Coverage:
 
       #. *Must have code coverage tracking for the package*
 
    #. Linters and Static Analysis
 
-      #. *Must have a code style and enforce it.*
-      #. *Must use static analysis tools where applicable.*
+      #. *Must have a code style and enforce it*
+      #. *Must use static analysis tools where applicable*
 
 #. **Dependencies:**
 
@@ -517,7 +517,7 @@ Requirements to be considered a 'Level 3' package:
    #. The same as 'Level 1' packages, except:
 
       #. *No public API needs to be explicitly declared, though this can make it harder to maintain API and ABI stability*
-      #. *No requirement to keep API/ABI stability within a stable ROS release, but it is recommended still*
+      #. *No requirement to keep API/ABI stability within a stable ROS release, but it is still recommended*
 
 #. **Change Control Process:**
 


### PR DESCRIPTION
First commit, haven't read/edited fully yet: 

- rearranged/rewrote abstract and motivation
- removed [ROS Core] points
- numbered requirements
- added DCO to change control level 1
- moved description to rationale
- added reference implementation content
- removed s.o. link
- small edits

Signed-off-by: maryaB-osr <marya@openrobotics.org>