### PR TITLE
REP-2000: Drop OpenEmbedded exception in rmw_cyclonedds_cpp Dashing support

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -397,7 +397,6 @@ Middleware Implementation Support:
 |                          |                     |               | and OpenEmbedded            |                                      |
 +--------------------------+---------------------+---------------+-----------------------------+--------------------------------------+
 | rmw_cyclonedds_cpp       | Eclipse Cyclone DDS | Tier 2        | All Platforms               | All Architectures                    |
-|                          |                     |               | except OpenEmbedded         |                                      |
 +--------------------------+---------------------+---------------+-----------------------------+--------------------------------------+
 | rmw_opensplice_cpp       | ADLink OpenSplice   | Tier 2        | All Platforms except Debian | All Architectures                    |
 |                          |                     |               | and OpenEmbedded            |                                      |


### PR DESCRIPTION
Support for building rmw-cyclonedds-cpp has been available in meta-ros
for Dashing since Milestone 10 (2020-01-07), so drop the exception for
it not being supported in Dashing.