### PR TITLE
REP 2005: Add meta-ros and superflore

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -148,6 +148,8 @@ All items on the list for the next distro should already be released into the ro
   * `ros-infrastructure/rosdep <https://github.com/ros-infrastructure/rosdep>`_ *(not a ROS package)*
   * `ros-infrastructure/rosdistro <https://github.com/ros-infrastructure/rosdistro>`_ *(not a ROS package)*
   * `ros-infrastructure/ros_buildfarm <https://github.com/ros-infrastructure/ros_buildfarm>`_ *(not a ROS package)*
+  * `ros-infrastructure/superflore <https://github.com/ros-infrastructure/superflore>`_ *(not a ROS package)*
+  * `ros/meta-ros <https://github.com/ros/meta-ros>`_ *(not a ROS package)*
   * `ament_cmake_ros/ament_cmake_ros <https://index.ros.org/p/ament_cmake_ros/>`_
   * `ament_cmake_ros/domain_coordinator <https://index.ros.org/p/domain_coordinator/>`_
 


### PR DESCRIPTION
- meta-ros: This is the OpenEmbedded layer for ROS. It is used to build ROS 2 packages for OpenEmbedded Linux and for webOS Open Source Edition.It is actively maintained for ROS 2 (a list of completed and future development milestones is [here](https://github.com/ros/meta-ros/wiki/Superflore-OE-Recipe-Generation-Scheme#milestones)) and is widely used (there are on average 20+ unique clones per day).
- superflore: An extended release manager for ROS. It is used to generate content for meta-ros from the ROS Index.