### PR TITLE
REP-2006: ROS 2 Security Vulnerability Disclosure Policy.

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -46,6 +46,14 @@ We aim that all of these packages are also:
 The list should be self-contained and exhaustive: if a package appears on the list, then all of its ROS 2 dependencies must also appear on the list (third-party or system dependencies should not be included).
 
 
+Security Reporting
+==================
+
+Maintainers of the packages below are expected to respond to security vulnerability reports in a timely matter as outlined in `REP-2006 <https://www.ros.org/reps/rep-2006.html>`_.
+The maintainers listed in the package.xml will be privately contacted with security vulnerability reports.
+This is to ensure that the security vulnerability is not disclosed before the timeline laid out in REP-2006.
+
+
 Change process
 ==============
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -49,7 +49,7 @@ The list should be self-contained and exhaustive: if a package appears on the li
 Security Reporting
 ==================
 
-Maintainers of the packages below are expected to respond to security vulnerability reports in a timely matter as outlined in `REP-2006 <https://www.ros.org/reps/rep-2006.html>`_.
+Maintainers of the packages below are expected to respond to security vulnerability reports in a timely manner as outlined in `REP-2006 <https://www.ros.org/reps/rep-2006.html>`_.
 The maintainers listed in the package.xml will be privately contacted with security vulnerability reports.
 This is to ensure that the security vulnerability is not disclosed before the timeline laid out in REP-2006.
 

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -40,7 +40,7 @@ If you already have a fix, please include it with your report.
 We may ask to exchange PGP keys to discuss sensitive details about the vulnerability which may include proof-of-concept code, an impact assessment, recommended remediation steps or other information that will help us find and fix the problem.
 
 Include any plans you may have to disclose details about the vulnerability.
-In order to protect our users, unless otherwise agreed by both parties, we ask that you not publicly discuss the vulnerability until at least 90 days have passed or the fix is published.
+In order to protect our users, unless otherwise agreed by both parties, we ask that you not publicly discuss the vulnerability until at least 90 days have passed from the initial contact with us or the fix is published.
 The group handling the report will also follow this timeline.
 If you do not wish to be acknowledged in the release communications please indicate so when you submit the vulnerability.
 

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -41,6 +41,7 @@ We may ask to exchange PGP keys to discuss sensitive details about the vulnerabi
 
 Include any plans you may have to disclose details about the vulnerability.
 In order to protect our users, we ask that you not publicly discuss the vulnerability until at least 90 days have passed or the fix is published.
+The group handling the report will also follow this timeline.
 If you do not wish to be acknowledged in the release communications please indicate so when you submit the vulnerability.
 
 What to expect in response to a vulnerability disclosure

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -1,0 +1,71 @@
+REP: 2006
+Title: ROS 2 Vulnerability Disclosure Policy
+Author: ROS 2 Security Working Group, Chris Lalancette <clalancette@openrobotics.org>
+Status: Active
+Type: Informational
+Content-TYpe: text/x-rst
+Created: 12-May-2020
+Post-History:
+
+
+Abstract
+========
+
+This REP describes the Vulnerability Disclosure Policy related to the ROS 2 Common Packages as defined in REP 2005.
+
+
+Motivation
+==========
+
+The developers of the Robot Operating System (ROS) take security very seriously.
+As such, we would like to be informed when a security bug is found so that it can be fixed and disclosed as quickly as possible.
+The rest of the document outlines what is covered by this policy and how to report security vulnerabilities.
+
+Scope
+=====
+
+The Vulnerability Disclosure Program outlined here covers all code within the ROS 2 Common Packages as defined in REP 2005.
+
+The ROS Security Working Group may also be able to assist you with reporting vulnerabilities which are not in scope of this policy but which are related to ROS or more generally to robotics.
+An increasing number of companies are bringing ROS-based products to market, and during this growth period we anticipate vulnerabilities to be identified in products before vendors have an established vulnerability reporting program.
+We will work with you on a best-effort basis to help connect you with the responsible vendor.
+
+How to submit a vulnerability
+=============================
+
+Please submit vulnerability reports by emailing security@ros2.org, preferably in English.
+This is a private list of security officers who can help verify the bug report and develop and release a fix.
+The more information provided about the bug, the easier it will be to fix.
+If you already have a fix, please include it with your report.
+We may ask to exchange PGP keys to discuss sensitive details about the vulnerability which may include proof-of-concept code, an impact assessment, recommended remediation steps or other information that will help us find and fix the problem.
+
+Include any plans you may have to disclose details about the vulnerability.
+In order to protect our users, we ask that you not publicly discuss the vulnerability until at least 90 days have passed or the fix is published.
+If you do not wish to be acknowledged in the release communications please indicate so when you submit the vulnerability.
+
+What to expect in response to a vulnerability disclosure
+========================================================
+
+Expect a timely response to your notification, normally within two business days, during which time we will triage your vulnerability report.
+
+After we have evaluated the vulnerability we will send you our risk assessment and, where applicable, the anticipated time to publish an update.
+We will aim at being as transparent as possible about timelines and any issues or challenges which may impact the scheduled fix.
+
+Should the vulnerability have a widespread impact that requires coordinated disclosure, we may, at our discretion, choose to engage a neutral third party such as CERT/CC or ICS-CERT to support coordination efforts.
+
+We will notify you when a pull request has been submitted and approved which remediates the vulnerability.
+Because security vulnerabilities can have severe consequences, they differ from other bugs and at our discretion-- in order to protect our users-- we may modify our normal code release processes for publishing open source code updates.
+
+Safe Harbor
+===========
+
+Open Robotics strongly supports security research into ROS software and seeks to encourage that research.
+Open Robotics will not engage in legal action against individuals who act in good faith to identify, report and fix vulnerabilities in ROS, so long as they operate in accordance with any applicable laws as well as this policy.
+Unauthorized research or testing against operating robotic systems is in violation of this policy and strongly discouraged due to potential health and human safety concerns.
+
+If at any time you have concerns about whether your activities are consistent with this policy, please contact us at security@ros2.org.
+
+Copyright
+=========
+
+This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -28,7 +28,7 @@ The Vulnerability Disclosure Program outlined here covers all code within the RO
 
 The ROS Security Working Group may also be able to assist you with reporting vulnerabilities which are not in scope of this policy but which are related to ROS or more generally to robotics.
 An increasing number of companies are bringing ROS-based products to market, and during this growth period we anticipate vulnerabilities to be identified in products before vendors have an established vulnerability reporting program.
-We will work with you on a best-effort basis to help connect you with the responsible vendor.
+We will work with you on a best-effort basis to help connect you with responsible parties best suited to address your concerns.
 
 How to submit a vulnerability
 =============================

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -61,7 +61,7 @@ Safe Harbor
 ===========
 
 Open Robotics strongly supports security research into ROS software and seeks to encourage that research.
-Open Robotics will not engage in legal action against individuals who act in good faith to identify, report and fix vulnerabilities in ROS, so long as they operate in accordance with any applicable laws as well as this policy.
+Open Robotics will not engage in legal action against individuals who act in good faith to identify, report and fix vulnerabilities in ROS, so long as they operate in accordance with any applicable laws or this policy.
 Unauthorized research or testing against operating robotic systems is in violation of this policy and strongly discouraged due to potential health and human safety concerns.
 
 If at any time you have concerns about whether your activities are consistent with this policy, please contact us at security@openrobotics.org.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -50,6 +50,7 @@ What to expect in response to a vulnerability disclosure
 Expect a timely response to your notification, normally within two business days, during which time we will triage your vulnerability report.
 
 After we have evaluated the vulnerability we will send you our risk assessment and, where applicable, the anticipated time to publish an update.
+Where appropriate, we will coordinate and assign a vulnerability ID with an industry-standard vulnerability database such as CVE.
 We will aim at being as transparent as possible about timelines and any issues or challenges which may impact the scheduled fix.
 
 Should the vulnerability have a widespread impact that requires coordinated disclosure, we may, at our discretion, choose to engage a neutral third party such as CERT/CC or ICS-CERT to support coordination efforts.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -69,4 +69,4 @@ If at any time you have concerns about whether your activities are consistent wi
 Copyright
 =========
 
-This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.
+This document has been placed in the public domain.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -69,4 +69,4 @@ If at any time you have concerns about whether your activities are consistent wi
 Copyright
 =========
 
-This document has been placed in the public domain.
+This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -3,7 +3,7 @@ Title: ROS 2 Vulnerability Disclosure Policy
 Author: ROS 2 Security Working Group, Chris Lalancette <clalancette@openrobotics.org>
 Status: Active
 Type: Informational
-Content-TYpe: text/x-rst
+Content-Type: text/x-rst
 Created: 12-May-2020
 Post-History:
 

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -11,7 +11,7 @@ Post-History:
 Abstract
 ========
 
-This REP describes the Vulnerability Disclosure Policy related to the ROS 2 Common Packages as defined in REP 2005.
+This REP describes the Vulnerability Disclosure Policy related to the ROS 2 Common Packages as defined in `REP-2005 <https://www.ros.org/reps/rep-2005.html>`_.
 
 
 Motivation
@@ -63,7 +63,7 @@ Safe Harbor
 
 Open Robotics strongly supports security research into ROS software and seeks to encourage that research.
 Open Robotics will not engage in legal action against individuals who act in good faith to identify, report and fix vulnerabilities in ROS, so long as they operate in accordance with any applicable laws or this policy.
-Unauthorized research or testing against operating robotic systems is in violation of this policy and strongly discouraged due to potential health and human safety concerns.
+Research or testing against operating robotic systems without the consent of the owner/operator is in violation of this policy and strongly discouraged due to potential health and human safety concerns.
 
 If at any time you have concerns about whether your activities are consistent with this policy, please contact us at security@openrobotics.org.
 

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -50,7 +50,7 @@ What to expect in response to a vulnerability disclosure
 Expect a timely response to your notification, normally within two business days, during which time we will triage your vulnerability report.
 
 After we have evaluated the vulnerability we will send you our risk assessment and, where applicable, the anticipated time to publish an update.
-Where appropriate, we will coordinate and assign a vulnerability ID with an industry-standard vulnerability database such as CVE.
+Where appropriate, we will coordinate and assign a vulnerability ID with an industry-standard.
 We will aim at being as transparent as possible about timelines and any issues or challenges which may impact the scheduled fix.
 
 Should the vulnerability have a widespread impact that requires coordinated disclosure, we may, at our discretion, choose to engage a neutral third party such as CERT/CC or ICS-CERT to support coordination efforts.

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -33,7 +33,7 @@ We will work with you on a best-effort basis to help connect you with the respon
 How to submit a vulnerability
 =============================
 
-Please submit vulnerability reports by emailing security@ros2.org, preferably in English.
+Please submit vulnerability reports by emailing security@openrobotics.org, preferably in English.
 This is a private list of security officers who can help verify the bug report and develop and release a fix.
 The more information provided about the bug, the easier it will be to fix.
 If you already have a fix, please include it with your report.
@@ -63,7 +63,7 @@ Open Robotics strongly supports security research into ROS software and seeks to
 Open Robotics will not engage in legal action against individuals who act in good faith to identify, report and fix vulnerabilities in ROS, so long as they operate in accordance with any applicable laws as well as this policy.
 Unauthorized research or testing against operating robotic systems is in violation of this policy and strongly discouraged due to potential health and human safety concerns.
 
-If at any time you have concerns about whether your activities are consistent with this policy, please contact us at security@ros2.org.
+If at any time you have concerns about whether your activities are consistent with this policy, please contact us at security@openrobotics.org.
 
 Copyright
 =========

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -40,7 +40,7 @@ If you already have a fix, please include it with your report.
 We may ask to exchange PGP keys to discuss sensitive details about the vulnerability which may include proof-of-concept code, an impact assessment, recommended remediation steps or other information that will help us find and fix the problem.
 
 Include any plans you may have to disclose details about the vulnerability.
-In order to protect our users, unless otherwise agreed by both parties, we ask that you not publicly discuss the vulnerability until at least 90 days have passed from the initial contact with us or the fix is published.
+In order to protect our users, unless otherwise agreed by both parties, we ask that you not publicly discuss the vulnerability until a fix is published or at least 90 days have passed since the initial report submission.
 The group handling the report will also follow this timeline.
 If you do not wish to be acknowledged in the release communications please indicate so when you submit the vulnerability.
 

--- a/rep-2006.rst
+++ b/rep-2006.rst
@@ -40,7 +40,7 @@ If you already have a fix, please include it with your report.
 We may ask to exchange PGP keys to discuss sensitive details about the vulnerability which may include proof-of-concept code, an impact assessment, recommended remediation steps or other information that will help us find and fix the problem.
 
 Include any plans you may have to disclose details about the vulnerability.
-In order to protect our users, we ask that you not publicly discuss the vulnerability until at least 90 days have passed or the fix is published.
+In order to protect our users, unless otherwise agreed by both parties, we ask that you not publicly discuss the vulnerability until at least 90 days have passed or the fix is published.
 The group handling the report will also follow this timeline.
 If you do not wish to be acknowledged in the release communications please indicate so when you submit the vulnerability.
 


### PR DESCRIPTION
This PR adds in REP-2006, which is the Security Vulnerability Disclosure Policy for ROS 2.  The original proposal was drafted by the [ROS 2 Security Working Group](http://wiki.ros.org/ROS2/WorkingGroups/Security), with some further edits by myself and @SidFaber .

We've decided to open this as a REP (rather than just documentation) since it affects all of the ROS 2 Common Packages in REP-2005.  Thus we would like to give the community a chance to weigh in on this policy.

@chapulina @ros2/security_working_group @thomas-moulard FYI.