### PR TITLE
Proposal to add Ouster ROS2 Drivers

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -429,6 +429,7 @@ All items on the list for the next distro should already be released into the ro
     * `phidgets_drivers/phidgets_spatial <https://index.ros.org/p/phidgets_spatial/>`_
     * `phidgets_drivers/phidgets_temperature <https://index.ros.org/p/phidgets_temperature/>`_
     * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
+    * `stevemacenski/ros2_ouster_drivers <https://github.com/SteveMacenski/ros2_ouster_drivers>`_
 
 * Documentation, Examples, Tutorials
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -429,7 +429,7 @@ All items on the list for the next distro should already be released into the ro
     * `phidgets_drivers/phidgets_spatial <https://index.ros.org/p/phidgets_spatial/>`_
     * `phidgets_drivers/phidgets_temperature <https://index.ros.org/p/phidgets_temperature/>`_
     * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
-    * `stevemacenski/ros2_ouster_drivers <https://github.com/SteveMacenski/ros2_ouster_drivers>`_
+    * `stevemacenski/ros2_ouster_drivers <https://github.com/ros-drivers/ros2_ouster_drivers>`_
 
 * Documentation, Examples, Tutorials
 

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -429,7 +429,7 @@ All items on the list for the next distro should already be released into the ro
     * `phidgets_drivers/phidgets_spatial <https://index.ros.org/p/phidgets_spatial/>`_
     * `phidgets_drivers/phidgets_temperature <https://index.ros.org/p/phidgets_temperature/>`_
     * `KumarRobotics/imu_vn_100 <https://github.com/KumarRobotics/imu_vn_100>`_
-    * `stevemacenski/ros2_ouster_drivers <https://github.com/ros-drivers/ros2_ouster_drivers>`_
+    * `ros-drivers/ros2_ouster_drivers <https://github.com/ros-drivers/ros2_ouster_drivers>`_
 
 * Documentation, Examples, Tutorials
 


### PR DESCRIPTION
This is a proposal to add the ROS2 Ouster driver to the REP 2005 common packages definition.

This package is analog to Velodyne drivers and is suitable for a large scope of navigation, autonomous vehicle and general perception tasks. They have been built against a design doc, making use of the modern tools that ROS2 enables including Lifecycle and Components, with serious consideration to performance and soft real-time requirements. It also has the official support of Ouster LIDAR. 

It has a mere 22 stars at the moment, but I think the reuse is clear. Users include Box Robotics @tpanzarella and Rover Robotics @rotu with 2 very active maintainers: Tom and I. 

We have CI setup and run the full suite of ROS2 linters with (what some may consider excessive) documentation on the API, explanation of features, networking setup assistance, and youtube videos explaining how to use and lidar features. 

Extensive tests are currently lacking due to the HIL nature of testing something like this as a hardware driver. I'm chatting with Ouster right now to potentially get testing resources in the form of recommendations and potentially an automated build setup with a lidar in their office for complete HIL testing, far more than an existing sensor driver on this list or available in the ROS2 ecosystem.  