### PR TITLE
Proposal to add Slam Toolbox to REP 2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -400,6 +400,7 @@ All items on the list for the next distro should already be released into the ro
   * `message_filters/message_filters <https://index.ros.org/p/message_filters/>`_
   * `sros2/sros2 <https://index.ros.org/p/sros2/>`_
   * `sros2/sros2_cmake <https://index.ros.org/p/sros2_cmake/>`_
+  * `stevemacenski/slam_toolbox <https://github.com/SteveMacenski/slam_toolbox/>`_
   * `teleop_twist_joy/teleop_twist_joy <https://index.ros.org/p/teleop_twist_joy/>`_
   * `ubuntu-robotics/ament_nodl <https://github.com/ubuntu-robotics/ament_nodl>`_
   * `ubuntu-robotics/nodl_python <https://github.com/ubuntu-robotics/nodl>`_


### PR DESCRIPTION
This is a proposal to add SLAM Toolbox to the REP 2005 common packages definition. ROSCon video can be seen here: https://vimeo.com/378682207. 

This package is the ROS2 default SLAM vendor for Navigation and the ecosystem. We have decided to archive Gmapping after years of not-so-awesome reviews and practical use. SLAM Toolbox is itself a big extension on top of (and inside of) Open Karto, effectively superseding that project as well for ROS2 with a large number of improvements including:
- Multisession mapping
- Towards live, multirobot distributed mapping
- Localization
- Experimental lifelong mapping mode
- RVIZ operations tools and map merging
- Pose graph manipulation
- Optimizer backend plugins with support for Ceres and partial support for G2O, GTSAM.

Existing SLAM packages in ROS have been literally or effectively abandoned in open-source (gmapping, karto, cartographer) as companies make their modifications in private. This represents one of the few SLAM packages even available in ROS2 and certainly the best maintained and developed by any open-source SLAM package's standards. This package is in my queue alongside Navigation2 and Robot Localization as a Tier 1 supported package, receiving a response within 24 hours to any new ticket on work days (except questions better suited to ROS Answers, which I immediately close and ask them to move). 

At the moment, it has just shy of 300 stars and about 90 forks. I think the "clear evidence of reuse" is evident, but I can provide specific companies that have approached me about their use privately with any TSC representatives or OR staff should more detail be required. I can (obviously) name Simbe Robotics, having developed it there. There are 15 current contributors to the project, so that's another good KPI. 

We have CI setup and run the full suite of ROS2 linters with (what some may consider excessive) documentation on the API, explanation of features, and parameters. 

