### PR TITLE
Add R_L to REP 2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -383,6 +383,7 @@ All items on the list for the next distro should already be released into the ro
     * `moveit2/moveit <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_kinematics <https://github.com/ros-planning/moveit2/>`_
 
+  * `cra-ros-pkg/robot_localization <https://github.com/cra-ros-pkg/robot_localization/>`_
   * `interactive_markers/interactive_markers <https://index.ros.org/p/interactive_markers/>`_
   * `geometry2/examples_tf2_py <https://index.ros.org/p/examples_tf2_py/>`_
   * `geometry2/geometry2 <https://index.ros.org/p/geometry2/>`_


### PR DESCRIPTION
This is a proposal to add Robot Localization to the REP 2005 common packages definition. ROSCon video can be seen here: https://www.youtube.com/watch?v=nfvvpYBAMww.

This package is the ROS/2 default state estimation and GPS processing vendor in the ecosystem, utilized by Navigation, Autoware, and countless drone, agriculture, and other ROS projects. Really, I think you'd find a hard time finding a robust robot system in ROS that doesn't use it. Basic feature set:

- Odometry sensor fusion
- Global localization technology fusion
- GPS processing and fusion

 This package is in my queue alongside Navigation2 and d SLAM Toolbox as a Tier 1 supported package, receiving a response within 24 hours to any new ticket on work days (except questions better suited to ROS Answers, which I immediately close and ask them to move). This is also maintained by Tom Moore from Locus Robotics, though I am the primary maintainer in ROS2. 

At the moment, it has exactly 500 stars and 440 forks. I think the "clear evidence of reuse" is evident.  There are 41 current contributors to the project, so that's another good KPI. If anyone needs more evidence, I can provide you with a truckload. 

We have CI setup and run the full suite of ROS2 linters with extremely excellent externally hosted documentation. It also has many integration and unit tests, though at the moment I don't have exact metrics, but we run them over 40 minutes of bag files and edge case testing.