### PR TITLE
REP 0153: Add `rolling` as a well-defined distribution_status.

### DIFF
--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -116,6 +116,7 @@ Index file
       * ``active``: A distribution which has been released and is actively
         being supported
       * ``end-of-life``: A distribution which has reached its end of life
+      * ``rolling``: A rolling distribution as described by REP 2002 [8]_
 
     * distribution_type: an optional string describing the type of the ROS
       distribution.
@@ -244,6 +245,7 @@ References
 .. [6] bloom PR to support v4 https://github.com/ros-infrastructure/bloom/pull/493
 .. [7] Second patch to python-rosdistro:
   https://github.com/ros-infrastructure/rosdistro/pull/147
+.. [8] REP 2002: http://www.ros.org/reps/rep-2002.html
 
 
 Copyright


### PR DESCRIPTION
This additional semantic distribution_status is suggested in [REP 2002](https://www.ros.org/reps/rep-2002.html#changes-to-rosdistro-distribution-files). #REP