### PR TITLE
Remove the redundant table of contents declarations

### DIFF
--- a/rep-0126.rst
+++ b/rep-0126.rst
@@ -7,21 +7,6 @@ Content-Type: text/x-rst
 Created: 10-Feb-2012
 Post-History: 20-Feb-2012
 
-Table of Contents
-=================
-
-#. Abstract_
-#. Background_
-#. Specification_
-#. Motivation_
-#. Rationale_
-#. Concerns_
-#. ReferenceImplementation_
-#. References_
-#. Copyright_
-
-.. _Abstract:
-
 Abstract
 ========
 
@@ -33,8 +18,6 @@ Note: the elements specified in this REP will only affect the tools
 used together with rosbuild packages: namely *rosinstall* and
 *rosws*. Newer tools like *wstool* intended to be used with catkin
 packages are not affected by these elements and will ignore them.
-
-.. _Background:
 
 Background
 ==========
@@ -124,8 +107,6 @@ environments. rosinstall generated setup files aim to enable a
 quick transistion between environments (and distros) by sourcing
 a given setup.sh.
 
-.. _Specification:
-
 Specification
 =============
 
@@ -156,9 +137,6 @@ And the local ``setup.sh`` will look like this::
 
   . /opt/ros/fuerte/setup.sh
   export ROS_PACKAGE_PATH=bar:...:/opt/ros/fuerte/share/ros:foo
-
-
-.. _Motivation:
 
 Motivation
 ==========
@@ -210,8 +188,6 @@ to use.
 This REP declares therefore a necessary amendment to rosinstall 
 to get and to store the location of a distro setup.sh file to be 
 used for generation of environment setup.sh files.
-
-.. _Rationale:
 
 Rationale
 =========
@@ -305,8 +281,6 @@ used both for getting the location of the setup file from a
 remote .rosinstall file as well as storing the information 
 in a local .rosinstall file. C.2. and C.3. seemed to lack in 
 transparency.
-
-.. _Concerns:
 
 Concerns
 ========
@@ -404,8 +378,6 @@ Reference implementation
 
 A reference implementation is the last version of rosinstall in the
 source repository. [4]_
-
-.. _References:
 
 References
 ==========

--- a/rep-0132.rst
+++ b/rep-0132.rst
@@ -7,8 +7,6 @@ Content-Type: text/x-rst
 Created: 22-Jan-2013
 Post-History: 10-April-2013
 
-.. contents::
-
 Abstract
 ========
 This REP describes incorporating package changelogs (i.e. a list of changes made to the package in each release) as part of the package source tree rather than being maintained separately on the ROS wiki. This is to address shortcomings with maintaining a separate changelog list.

--- a/rep-0136.rst
+++ b/rep-0136.rst
@@ -7,8 +7,6 @@ Content-Type: text/x-rst
 Created: 15-Feb-2013
 Post-History: 7-March-2013
 
-.. contents::
-
 Abstract
 ========
 This REP forms the recommendation for how to handle releases of third party, non catkin packages using the ROS community release infrastructure. Specifically, this REP aims to provide a recommendation on how to release a third party package into a ROS distribution, in the event that the third party package cannot be released in a ROS distribution agnostic manner.

--- a/rep-0137.rst
+++ b/rep-0137.rst
@@ -7,8 +7,6 @@ Content-Type: text/x-rst
 Created: 04-Feb-2013
 Post-History: 19-April-2013
 
-.. contents::
-
 Abstract
 ========
 This REP specifies a set of files which define ROS distributions and

--- a/rep-0141.rst
+++ b/rep-0141.rst
@@ -7,8 +7,6 @@ Content-Type: text/x-rst
 Created: 18-Dec-2013
 Post-History: 18-Dec-2013
 
-.. contents::
-
 Abstract
 ========
 This REP specifies a set of files which define ROS distributions and

--- a/rep-0143.rst
+++ b/rep-0143.rst
@@ -7,9 +7,6 @@ Content-Type: text/x-rst
 Created: 01-Sep-2014
 Post-History: 25-Nov-2014
 
-
-.. contents::
-
 Abstract
 ========
 This REP updates the specification of the ROS distribution files facilitated in

--- a/rep-0153.rst
+++ b/rep-0153.rst
@@ -7,9 +7,6 @@ Content-Type: text/x-rst
 Created: 27-Oct-2018
 Post-History: 09-Nov-2018, 01-Oct-2019, 03-Dec-2019
 
-
-.. contents::
-
 Abstract
 ========
 This REP updates the specification of the ROS distribution files facilitated in


### PR DESCRIPTION
The Table of contents is in the layout already this was leading to documents with two tables of contents in sequence.

Noticed by @nuclearsandwich 
![toc](https://user-images.githubusercontent.com/447804/84721755-37f32d80-af36-11ea-96ba-b0392f326c6a.png)
