### PR TITLE
Adding navigation.ros.org to REP-2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -358,6 +358,7 @@ All items on the list for the next distro should already be released into the ro
     * `navigation2/nav_2d_msgs <https://index.ros.org/p/nav_2d_msgs/>`_
     * `navigation2/nav_2d_utils <https://index.ros.org/p/nav_2d_utils/>`_
     * `navigation2/navigation2 <https://index.ros.org/p/navigation2/>`_
+    * `navigation.ros.org <https://github.com/ros-planning/navigation.ros.org/>`_
 
   * MoveIt2
 


### PR DESCRIPTION
Adding navigation website / documentation source to REP-2005 for TSC contribution tracking. I don't think anyone disagrees the value of supported documentation, so keeping this one short. 