### PR TITLE
Adding bond_core, bondcpp, bondpy to REP 2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -406,6 +406,7 @@ All items on the list for the next distro should already be released into the ro
   * `geometry2/tf2_tools <https://index.ros.org/p/tf2_tools/>`_
   * `kdl_parser/kdl_parser <https://index.ros.org/p/kdl_parser/>`_
   * `message_filters/message_filters <https://index.ros.org/p/message_filters/>`_
+  * `ros/bond_core <https://github.com/ros/bond_core/>`_
   * `sros2/sros2 <https://index.ros.org/p/sros2/>`_
   * `sros2/sros2_cmake <https://index.ros.org/p/sros2_cmake/>`_
   * `teleop_twist_joy/teleop_twist_joy <https://index.ros.org/p/teleop_twist_joy/>`_


### PR DESCRIPTION
Adding [bond](https://github.com/ros/bond_core) to REP-2005. It has clear use across a large number of projects for checking that servers are still spinning. There is a basic ROS2 port but could use some work to allow for lifecycle support (https://github.com/ros/bond_core/pull/64) and release into ROS2. 