### PR TITLE
update REP 149 to enable quoted literals in conditions

### DIFF
--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Oct-2017
-Post-History: 02-Jan-2018
+Post-History: 02-Jan-2018, 31-Aug-2020
 
 Outline
 =======
@@ -608,6 +608,8 @@ Attributes
   * variable names which start with a `$` sign and are followed by
     alphanumerics and underscores
   * literals which can only contain alphanumerics, underscores and dashes
+  * quoted literals (single or double quotes) which can contain any characters
+    except the used quote character
   * arbitrary whitespaces between these tokens
 
  An expression syntactically correct by the previous definition will be

--- a/xsd/package_format3.xsd
+++ b/xsd/package_format3.xsd
@@ -32,7 +32,7 @@
         <xs:attribute name="condition" use="optional">
           <xs:simpleType>
             <xs:restriction base="xs:token">
-              <xs:pattern value="[$A-Za-z0-9_\s&lt;&gt;!=()-]*"/>
+              <xs:pattern value="[$A-Za-z0-9_\s&quot;'&lt;&gt;!=()-]*"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>


### PR DESCRIPTION
Atm literals can't contain single / double quotes and as a result a an empty string can't be expressed, e.g. the following are invalid expressions:

* `$FOO == `
* `$FOO == ''`
* `$FOO == ""`
* (and there is no `not` operator either: `not $FOO`)

The only way to express these conditions atm is to use a certainly undefined variable (which will evaluate to an empty string):

* `$FOO == $UNIQUE_NAME_WHICH_CERTAINLY_DOES_NOT_EXIST_SO_EVALUATES_TO_AN_EMPTY_STRING`

---

This update allows to use single or double quotes to quote literals which allows to represent an empty string as well as strings with arbitrary characters (e.g. spaces or non-alphanumeric).

Considerations:
* Allowing these additional cases doesn't break any existing condition since the newly allowed quoted literals weren't valid before.
* Conditions making use of the proposed quoted literals will only be parsable by an updated parser (as proposed in ros-infrastructure/catkin_pkg#295).