### PR TITLE
Add GitHub Actions worflow for rep CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: rep-ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ['*']
+
+jobs:
+    build:
+      name: run rep tests
+      runs-on: ubuntu-18.04
+
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install docutils xmlschema
+      - name: Run tests
+        run: |
+          make


### PR DESCRIPTION
Travis CI is becoming increasingly unavailable. This ports the same test suite to run via GitHub Actions.