### PR TITLE
Add ros-tooling GitHub Action CI to REP-2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -579,6 +579,7 @@ All items on the list for the next distro should already be released into the ro
     * `rqt_tf_tree/rqt_tf_tree <https://index.ros.org/p/rqt_tf_tree/>`_
     * `rqt_topic/rqt_topic <https://index.ros.org/p/rqt_topic/>`_
   * CI tools
+
     * `ros-tooling/action-ros-ci <https://github.com/ros-tooling/action-ros-ci>`_ *(not a ROS package)*
     * `ros-tooling/action-ros-lint <https://github.com/ros-tooling/action-ros-lint>`_ *(not a ROS package)*
     * `ros-tooling/setup-ros <https://github.com/ros-tooling/setup-ros>`_ *(not a ROS package)*

--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -578,6 +578,10 @@ All items on the list for the next distro should already be released into the ro
     * `rqt_srv/rqt_srv <https://index.ros.org/p/rqt_srv/>`_
     * `rqt_tf_tree/rqt_tf_tree <https://index.ros.org/p/rqt_tf_tree/>`_
     * `rqt_topic/rqt_topic <https://index.ros.org/p/rqt_topic/>`_
+  * CI tools
+    * `ros-tooling/action-ros-ci <https://github.com/ros-tooling/action-ros-ci>`_ *(not a ROS package)*
+    * `ros-tooling/action-ros-lint <https://github.com/ros-tooling/action-ros-lint>`_ *(not a ROS package)*
+    * `ros-tooling/setup-ros <https://github.com/ros-tooling/setup-ros>`_ *(not a ROS package)*
 
 
 Copyright


### PR DESCRIPTION
Justification:
* Gaining usage across ecosystem
* Helps packages attain some REP-2004 quality bars easily and freely
* Has its own CI and unit testing