### PR TITLE
Correct Apache-2.0 license short identifier

### DIFF
--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -478,7 +478,7 @@ Most common open-source licenses are described on the
 
 Commonly used license strings:
 
- - Apache 2.0
+ - Apache-2.0
  - BSD
  - Boost Software License
  - GPLv2


### PR DESCRIPTION
According to the following sources, there is a missing "-" in the Apache license's short identifier.

* https://opensource.org/licenses/Apache-2.0
* https://spdx.org/licenses/Apache-2.0.html

** Why is this important?**
Many packages in ROS2 are using the Apache license. There are potential legal issues in the future if developers are using the wrong short identifier (as I was doing).