### PR TITLE
REP 2007: Type Adaptation

### DIFF
--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -122,6 +122,22 @@ If you wish, you may associate a custom type with a single ROS message type, all
    // message type is implied based on the previous statement.
    auto pub = node->create_publisher<std::string>(...);
 
+Note that it is also possible to use a ROS type with a publisher or subscriber that has been specialized to use a custom message, e.g.:
+
+.. code-block:: cpp
+
+   using AdaptedType = rclcpp::adapt_type<std::string>::as<std_msgs::msg::String>;
+   auto pub = node->create_publisher<AdaptedType>(...);
+
+   // Publish a std::string
+   std::string custom_msg = "My std::string"
+   pub->publish(custom_msg);
+
+   // Publish a std_msgs::msg::String;
+   auto ros_msg = std_msgs::msg::String();
+   ros_msg.data = "My std_msgs::msg::String";
+   pub->publish(ros_msg);
+
 Type Adaptation in Services
 ---------------------------
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -1,7 +1,7 @@
 REP: 2007
 Title: Adapting C++ Types
 Author: Audrow Nash <audrow@openrobotics.org>
-Status: Active
+Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Jan-2020

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -323,6 +323,7 @@ Comparison to ROS 1's Type Adaptation
 -------------------------------------
 
 Although intended to be similar in functionality, the proposed feature and ROS 1's type adaptation support [5]_ have a few important differences:
+
 * This feature will support both convert and (de)serialize functions, and require at least one or the other, but also allow both. The reason for this is that convert is superior for intra-process communication and the (de)serialization functions are better for inter-process communication.
 * This feature will also require the user to write less code when creating an adapter, as compared to the ROS 1 implementation.
 * An advantage of following the ROS 1 approach is that an extra copy can be avoided; although it is likely much more challenging to implement this feature the ROS 1 way because of the middleware.

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -20,12 +20,12 @@ Motivation
 The primary reason for this change is to improve the developer's experience working with ROS 2.
 Currently, developers often write code to convert a ROS interface into another custom data structure for use in their programs.
 This can be trivial, in the case accessing the ``data`` field in ``std_msgs::msg::String``;
-or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type [1]_.
+or more involved such as when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type [1]_.
 Such conversions are additional work for the programmer and are potential sources of errors.
 
 An additional reason for this change is performance.
 This interface will allow us to define methods for serializing directly to the user requested type, and/or using that type in intra-process communication without ever converting it.
-Whereas without this feature, even to send a ``cv::Mat`` from one publisher to a subscription in the same process would require converting it to a ``sensor_msgs::msg::Image`` first and then back again to ``cv::Mat``.
+Whereas without this feature, even to send a ``cv::Mat`` (or a data structure containing a ``cv::Mat``) from one publisher to a subscription in the same process would require converting it to a ``sensor_msgs::msg::Image`` first and then back again to ``cv::Mat``.
 
 
 Terminology
@@ -50,7 +50,7 @@ In that specialization they must:
 - specify the custom type with ``using custom_type = ...``,
 - specify the ROS type with ``using ros_message_type = ...``,
 - provide static convert functions with the signatures:
-   - ``static void convert_to_ros(const custom_type &, ros_message_type &)``,
+   - ``static void convert_to_ros_message(const custom_type &, ros_message_type &)``,
    - ``static void convert_to_custom(const ros_message_type &, custom_type &)``
 
 The convert functions must convert from one type to the other.
@@ -133,7 +133,7 @@ Note that it is also possible to use a ROS type with a publisher or subscriber t
    pub->publish(custom_msg);
 
    // Publish a std_msgs::msg::String;
-   auto ros_msg = std_msgs::msg::String();
+   std_msgs::msg::String ros_msg;
    ros_msg.data = "My std_msgs::msg::String";
    pub->publish(ros_msg);
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -13,7 +13,7 @@ Abstract
 
   A short (~200 word) description of the technical issue being addressed.
 
-This REP suggests a new feature for ROS 2's C++ client library that makes it easier to convert between ROS 2 interfaces and custom C++ data structures, such as ``std::string`` and ``cv::Mat``.
+This REP proposes an extension to publishers and subscribers in `rclcpp` to make it easier to convert between ROS 2 interfaces and custom C++ data structures.
 
 
 Motivation

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -1,5 +1,5 @@
 REP: 2007
-Title: Type Masquerading
+Title: Adapting C++ Types
 Author: Audrow Nash <audrow@openrobotics.org>
 Status: Active
 Type: Standard
@@ -13,7 +13,7 @@ Abstract
 
   A short (~200 word) description of the technical issue being addressed.
 
-This REP suggests a new feature for ROS 2's C++ client library that makes it easier to convert between ROS 2 interfaces and common C++ data structures, such as ``std::string`` and ``cv::Mat``.
+This REP suggests a new feature for ROS 2's C++ client library that makes it easier to convert between ROS 2 interfaces and custom C++ data structures, such as ``std::string`` and ``cv::Mat``.
 
 
 Motivation
@@ -24,51 +24,58 @@ Motivation
 The primary reason for this change is to improve the developer's experience working with ROS 2.
 Currently, a developer often has to write code to convert a ROS interface into another data structure for use.
 This can be trivial, in the case accessing the ``data`` field in ``std_msgs::msg::String``;
-or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type (`here <https://github.com/ros2/demos/blob/11e00ecf7eec25320f950227531119940496d615/image_tools/src/cam2image.cpp#L277-L291>`_).
+or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type [1]_.
 Such conversions are additional work for the programmer and are potential sources of errors.
-This work seeks to provide a 
+
+Terminology
+===========
+
+.. glossary::
+     Custom type (in code, ``CustomType``)
+       A data structure that *is not* a ROS 2 interface, such as ``std::string`` or ``cv::Mat``.
+     ROS type (in code, ``RosType``)
+       A data structure that *is* a ROS 2 interface, such as ``std_msgs::msg::String`` or ``sensor_msgs::msg::Image``.
 
 Specification
 =============
 
   The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current ROS client libraries, if applicable (roscpp, rospy, roslisp, etc...).
 
-While the term of this REP is still selected, the general structure can be thought of as follows, using ``TypeMasquerade`` in this case.
+There are different tiers of expressivity in the syntax for type adaptation, including both explicit to implicit forms.
+The explicit forms require the custom type and the ROS type to be specified; while the implicit form makes an assumption about the ROS type based on the custom type.
+The explicit forms could be used to clearly communicate what is happening, which may be useful in examples or tutorials, or may be used depending on the preferences of the developer.
+While the implicit, and most concise, form will primarily be used for its convenience (although it lacks some of the functionality of the explicit forms).
 
-  template<class From, class To>
-  struct TypeMapping
-  {
-    // This is where the conversion would occur
-  };
+Below are examples of different syntaxes for type adaptation.
+In these examples and using the terminology above, ``std::string`` would be considered the custom type and the ROS interface ``std_msgs::msg::String`` would be considered the ROS type.
+Note that for every publisher created in the examples below, a ``std::string`` type variable (the custom type) would be adapted to be published on the ROS network as a ``std_msgs::msg::String`` (the ROS type).
 
-  template<class From>
-  struct TypeMasquerade {
-    template<class To>
-    using as = TypeMapping<From, To>;
-  };
+.. code-block:: cpp
 
-Where there are four different tiers of how type masquerading could be expressed.
+   // Explicit Form 1: Most explicit
+   using MsgT = rclcpp::TypeAdapt<std::string>::to<std_msgs::msg::String>;
+   rclcpp::Publisher<MsgT>::SharedPtr publisher1_;
 
-The most explicit, could look like this::
+The most explicit form could be shortened in the following to ways:
 
-  using MsgT = rclcpp::TypeMasquerade<std_msgs::msg::String>::as<std::string>;
-  rclcpp::Publisher<MsgT>::SharedPtr publisher_;
+.. code-block:: cpp
 
-You would use this if you want it to be clear what is happening (maybe examples or depending on the preferences of the developer), or you might use it when `std::string` could map to more than one ROS type and you need to select which one to use.
+   // Explicit Form 2
+   rclcpp::Publisher<TypeAdapt<std::string, std_msgs::msg::String>>::SharedPtr publisher2_;
 
-We could have a short form of this that takes two arguments::
+   // Explicit Form 3
+   rclcpp::Publisher<std::string, std_msgs::msg::String>::SharedPtr publisher_3;
 
-  rclcpp::Publisher<TypeMapping<std_msgs::msg::String, std::string>>::SharedPtr publisher_;
+Note that the 3rd explicit form may be prohibitively complicated to implement since there are multiple template arguments already for publishers and subscribers.
 
-Or this, but it might be prohibitively complicated to implement since there are multiple template arguments already for Publisher/Subscription::
+The final shorthand, performs an implicit type adaptation with the custom type ``std::string`` which will be adapted to the ROS type``std_msgs::msg::String``:
 
-  rclcpp::Publisher<std_msgs::msg::String, std::string>::SharedPtr publisher_;
+.. code-block:: cpp
 
-Or you can be implicit::
+   // Implicit Form
+   rclcpp::Publisher<std::string>::SharedPtr publisher_4;
 
-  rclcpp::Publisher<std::string>::SharedPtr publisher_;
-
-If ``std::string`` has multiple types it could represent then this has to error.
+In this final form, if ``std::string`` has multiple types it could represent, then an error will be raised during compilation.
 
 
 Rationale
@@ -76,105 +83,122 @@ Rationale
 
   The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
 
-  The rationale should provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
+Selecting a term
+----------------
 
-Putting it in ``rclcpp``
-------------------------
+There are various terms that may be suitable for type adapting feature described.
+In selecting a term,  
 
-It is thought that this should be put in the C++ client library for the following reasons:
+:High priority:
 
-* Take advantage of C++'s templating system
+* Clearly communicate the described feature
+* Clearly communicate the order of custom type and ROS type arguments
 
-Picking a term
----------------
+:Low priority:
 
-Goals
-"""""
+* The custom type should be the first argument so that
+  * the custom type is the first argument in both the explicit and implicit syntax
+  * the custom type is read first, for convenience 
+* The syntax reads well
 
-High priority:
-* Clearly communicate the that one type of term
-* Clearly communicate the order of the ROS and C++ arguments
+Candidate terms
+^^^^^^^^^^^^^^^
 
-Low priority:
-* The C++ type should be on the left, so it is seen first
-* The order of the arguments shouldn't change in the two argument or one argument form
+Several possible terms were considered.
+Here is a brief summary of the discussion around different terms.
 
-Candidates
+Masquerade
 """"""""""
 
-"Masquerade" and "Facade" are the two terms that have been discussed at length. Some pros and cons for these terms are as follows:
+There is some precident for using masquerade in similar settings, IP Masquerading in the Linux kernel [2]_ for example.
+"Masquerade" is also a verb, which may make it easier to discuss among developers.
+However, it was thought that "Masquerade" would be a confusing word for non-English and non-French speakers.
+One disadvantage of "Masquerade" is that there is ambiguity in its usage.
+For example,
 
-+------------+--------------------------------------------------------------+--------------------------------------------+
-| **Term**   | **Pros**                                                     | **Cons**                                   |
-+------------+--------------------------------------------------------------+--------------------------------------------+
-| Masquerade | * Seems to be a common computer science concept,             | * An uncommon word that may be hard for    |
-|            |   for example <IP Masquerading in the Linux kernel           |   non-English and non-French speakers      |
-|            |   <http://linuxdocs.org/HOWTOs/IP-Masquerade-HOWTO-2.html>`_ |                                            |
-|            | * It is a verb, which perhaps makes it easier to discuss     |                                            |
-+------------+--------------------------------------------------------------+--------------------------------------------+
-| Facade     | * Seems to be a common programming concept for extending     | * Isn't a verb, so perhaps this will make  |
-|            |   object oriented behavior [4]_                              |   it harder to talk about in discussions   |
-|            | * Seems to be in the public vernacular                       |                                            |
-|            | * More correct in an object oriented sense                   |                                            |
-+------------+--------------------------------------------------------------+--------------------------------------------+
+.. code-block:: cpp
 
-We can also consider the anticipated usage for each of these terms:
+   Masquerade<std_msgs::msg::String>::as<std::string>
 
-+------------+----------------------------------------------------------+
-| **Term**   | **Usage**                                                |
-+------------+----------------------------------------------------------+
-| Masquerade | ::                                                       |
-|            |                                                          |
-|            |   Masquerade<std_msgs::msg::String>::as<std::string>     |
-|            |                                                          |
-|            | or                                                       |
-|            |                                                          |
-|            | ::                                                       |
-|            |                                                          |
-|            |   Masquerade<std::string>::as<std_msgs::msg::String>     |
-+------------+----------------------------------------------------------+
-| Facade     | ::                                                       |
-|            |                                                          |
-|            |   Facade<std::string>::instead_of<std_msgs::msg::String> |
-+------------+----------------------------------------------------------+
+and
 
-A major disadvantage of "Masquerade" is that it is not clear which of the two usages is more correct.
-Given a different perspective, both make sense.
-This confusion may result in frustration on the part of the ROS 2 developer:
+.. code-block:: cpp
+
+   Masquerade<std::string>::as<std_msgs::msg::String>   
+
+both seem to make sense.
+This ambiguity may result in frustration on the part of the ROS 2 developer:
+
 * frequently having to refer back to documentation
 * possibly opaque error messages
 
-While "Facade" does seem to be clearerd in terms of arguments, it has been pointed out the ``::instead_of`` syntax doesn't read well.
-In addition, the "Facade pattern" [4]_ seems to be more about simplifying an interface, where as in our case, we are proposing to convert one data type to another behind the scenes.
+Facade
+^^^^^^
+
+"Facade" seems to be a more common English word than "masquerade".
+It also is commonly used as a design pattern in object oriented programming.
+However, the "Facade pattern" is typically used to simplify a complex interface [3]_, which is not the major feature being proposed here.
+
+It was thought to use "Facade" in the following form:
+
+.. code-block:: cpp
+
+   Facade<std::string>::instead_of<std_msgs::msg::String>
 
 
-Alternative choices
-"""""""""""""""""""
+Adapt
+^^^^^
 
-Other possible suggestions (ranked by Audrow's opinion, with best at the top):
-* ``TypeAdapter<CppType>::to<RosType>``, follows Adapter pattern [6]_ - also most consistent with [3]_
-* ``TypeWrapper<CppType>::to<RosType>``
-* ``TypeMap<CppType>::to<RosType>``
-* ``TypeUse<CppType>::instead_of<RosType>``
-* ``TypeAccept<CppType>::as<RosType>``
-* ``TypeConvert<RosType>::to<CppType>``
+"Adapt" is certainly a common English word, and the "Adapter pattern" is a common design pattern for adjusting an interface [4]_, which matches well with the feature being suggested here.
+Also, using "Adapt" is consistent with the documentation of a similar feature in ROS 1 (i.e., "Adapting C++ Types" [5]_).
 
-Suggested but discarded
-* Disguise: Discarded in favor of "Facade"
-* Decorate: Refers to the decorator pattern, which is not quite what we're doing here as our operations will occur at compile time, not run-time
-* Mask: Overloaded as a computer science term [5]_
+"Adapt" also has the advantage of being a verb and of being related to the noun "Adapter".
+This flexiblity may make it easier for developers to discuss its use.
 
-Prepending the word "Type"
-""""""""""""""""""""""""""
+"Adapt" could be used in the following syntax:
+
+.. code-block:: cpp
+
+   Adapt<std::string>::to<std_msgs::msg::String>
+
+Additional terms considered
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Here is a brief listing of additional terms that were considered and why they were not selected:
+
+:Convert: Passed in favor of "Adapt", which expresses a similar idea and has a common design pattern.
+
+:Decorate: Passed in favor of "Fascade", which seems to be more common.
+
+:Mask: Overloaded as a computer science term [6]_
+
+:Map: Expresses the idea well, but has a lot of meanings in math and programming.
+
+:Use: Possibly confusing with C++'s ``using`` keyword; also not terribly descriptive.
+
+:Wrap: Passed in favor of "Adapt", which seems to be more common.
+
+
+Prepending the selected term with "Type"
+----------------------------------------
 
 Most of the terms being considered refer to a general design pattern and, thus, may be used in other ROS features.
-To reduce ambiguity, prefixing the term with "Type" would make its usage clearer and help avoid name collisions.
+To reduce ambiguity, prefixing the term with "Type" would make its usage clearer and help avoid name collisions and should make it easier for developers to find documentation.
 
+
+Adding this feature in ``rclcpp``
+---------------------------------
+
+Placing this feature in ROS 2's C client library, ``rcl``, would allow this feature to be used in other client libraries, such as ``rclcpp`` and ``rclpy``.
+However, it is not clear that the difficulty of implementing this feature in ``rcl`` is worth the benefit to other client libraries.
+Placing this feature in ``rclcpp``, ROS 2's C++ client library, would allow implementation to take advantage of C++'s standard template library.
 
 Backwards Compatibility
 =======================
 
   All REPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The REP must explain how the author proposes to deal with these incompatibilities. REP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+The proposed feature adds new functionality while not modifying existing functionality.
 
 
 Reference Implementation
@@ -184,24 +208,29 @@ Reference Implementation
 
   The final implementation must include test code and documentation.
 
-  An example usage of references [1]_.
-
+TK.
 
 References
 ==========
 
-.. [1] REP 1, REP Purpose and Guidelines, Warsaw, Hylton
-   (https://ros.org/reps/rep-0001.html)
-.. [2] Masquerade, Merriam-Webster
-   (https://www.merriam-webster.com/dictionary/masquerade)
-.. [3] Adapting C++ Types
-   (http://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes#Adapting_C.2B-.2B-_Types)
-.. [4] Facade Pattern
+.. [1] ``cam2image.cpp`` demo 
+   (https://github.com/ros2/demos/blob/11e00ecf7eec25320f950227531119940496d615/image_tools/src/cam2image.cpp#L277-L291)
+
+.. [2] IP Masquerading in the Linux Kernel
+   (http://linuxdocs.org/HOWTOs/IP-Masquerade-HOWTO-2.html)
+
+.. [3] Facade Pattern
    (https://en.wikipedia.org/wiki/Facade_pattern)
-.. [5] Masking (computing)
-   (https://en.wikipedia.org/wiki/Mask_(computing))
-.. [6] Adapter pattern
+
+.. [4] Adapter pattern
    (https://en.wikipedia.org/wiki/Adapter_pattern)
+
+.. [5] Adapting C++ Types
+   (http://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes#Adapting_C.2B-.2B-_Types)
+
+.. [6] Masking (computing)
+   (https://en.wikipedia.org/wiki/Mask_(computing))
+
 
 Copyright
 =========

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -334,10 +334,12 @@ Backwards Compatibility
 The proposed feature adds new functionality while not modifying existing functionality.
 
 
-Reference Implementation
-========================
 
-The current reference implementation is a work in progress and can be found `here <https://repl.it/@ros2/TypeMasquerading#audrow_main.cpp>`_.
+Feature Progress
+================
+
+The pull request `ros2/rclcpp#1557 <https://github.com/ros2/rclcpp/pull/1557>`_ implements the API for publishers and subscribers with the exception of the ``as`` syntax for defining a ``TypeAdapter`` specialization.
+Note that this pull request does not avoid converting the data during intraprocess communication.
 
 
 References

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -1,5 +1,5 @@
 REP: 2007
-Title: Adapting C++ Types
+Title: Type Adaptation Feature
 Author: Audrow Nash <audrow@openrobotics.org>
 Status: Draft
 Type: Standards Track
@@ -11,7 +11,7 @@ Post-History: 28-Jan-2020
 Abstract
 ========
 
-This REP proposes an extension to the creation of Publishers and Subscriptions in `rclcpp` to make it easier to convert between ROS 2 interfaces and custom C++ data structures.
+This REP proposes an extension to `rclcpp` that will make it easier to convert between ROS types and custom, user-defined types for topics, services, and action services.
 
 
 Motivation

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -1,11 +1,11 @@
 REP: 2007
 Title: Type Adaptation Feature
-Author: Audrow Nash <audrow@openrobotics.org>
-Status: Draft
+Author: Audrow Nash <audrow@openrobotics.org>, William Woodall <william@openrobotics.org>
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 28-Jan-2020
-Post-History: 28-Jan-2020
+Created: 28-Jan-2021
+Post-History:
 
 
 Abstract

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -245,7 +245,7 @@ This ambiguity may result in frustration on the part of the ROS 2 developer:
 * possibly opaque error messages
 
 Facade
-^^^^^^
+""""""
 
 "Facade" seems to be a more common English word than "masquerade".
 It also is commonly used as a design pattern in object oriented programming.
@@ -259,7 +259,7 @@ It was thought to use "Facade" in the following form:
 
 
 Adapter
-^^^^^^^
+"""""""
 
 "Adapter" is certainly a common English word, and the "Adapter pattern" is a common design pattern for adjusting an interface [4]_, which matches well with the feature being suggested here.
 Also, using "Adapter" is consistent with the documentation of a similar feature in ROS 1 (i.e., "Adapting C++ Types" [5]_).
@@ -274,7 +274,7 @@ This flexibility may make it easier for developers to discuss its use.
    TypeAdapter<std::string>::as<std_msgs::msg::String>
 
 Additional terms considered
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""
 
 Here is a brief listing of additional terms that were considered and why they were not selected:
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -57,7 +57,7 @@ Note that, for every publisher created in the examples below, a ``std::string`` 
    using MsgT = rclcpp::AdaptType<std::string>::to<std_msgs::msg::String>;
    auto pub1 = std::make_shared<rclcpp::Publisher<MsgT>>();
 
-The most explicit form could be shortened in the following to ways:
+The most explicit form could be shortened in the following ways:
 
 .. code-block:: cpp
 
@@ -110,7 +110,7 @@ Here is a brief summary of the discussion around different terms.
 Masquerade
 """"""""""
 
-There is some precident for using masquerade in similar settings, IP Masquerading in the Linux kernel [2]_ for example.
+There is some precedent for using masquerade in similar settings, IP Masquerading in the Linux kernel [2]_ for example.
 "Masquerade" is also a verb, which may make it easier to discuss among developers.
 However, it was thought that "Masquerade" would be a confusing word for non-English and non-French speakers.
 One disadvantage of "Masquerade" is that there is ambiguity in its usage.

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -212,7 +212,7 @@ Reference Implementation
 
   The final implementation must include test code and documentation.
 
-TK.
+The current reference implementation is a work in progress and can be found `here <https://repl.it/@ros2/TypeMasquerading#audrow_main.cpp>`_.
 
 References
 ==========

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -266,7 +266,7 @@ Adapter
 Also, using "Adapter" is consistent with the documentation of a similar feature in ROS 1 (i.e., "Adapting C++ Types" [5]_).
 
 "Adapter" also has the advantage of being a noun and of being related to the verb "Adapt".
-This flexiblity may make it easier for developers to discuss its use.
+This flexibility may make it easier for developers to discuss its use.
 
 "Adapter" could be used in the following syntax:
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -1,0 +1,219 @@
+REP: 2007
+Title: Type Masquerading
+Author: Audrow Nash <audrow@openrobotics.org>
+Status: Active
+Type: Standard
+Content-Type: text/x-rst
+Created: 28-Jan-2020
+Post-History: 28-Jan-2020
+
+
+Abstract
+========
+
+  A short (~200 word) description of the technical issue being addressed.
+
+This REP suggests a new feature for ROS 2's C++ client library that makes it easier to convert between ROS 2 interfaces and common C++ data structures, such as ``std::string`` and ``cv::Mat``.
+
+
+Motivation
+==========
+
+  The motivation is critical for REPs that want to change the ROS APIs. It should clearly explain why the existing API specification is inadequate to address the problem that the REP solves. REP submissions without sufficient motivation may be rejected outright.
+
+The primary reason for this change is to improve the developer's experience working with ROS 2.
+Currently, a developer often has to write code to convert a ROS interface into another data structure for use.
+This can be trivial, in the case accessing the ``data`` field in ``std_msgs::msg::String``;
+or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type (`here <https://github.com/ros2/demos/blob/11e00ecf7eec25320f950227531119940496d615/image_tools/src/cam2image.cpp#L277-L291>`_).
+Such conversions are additional work for the programmer and are potential sources of errors.
+This work seeks to provide a 
+
+Specification
+=============
+
+  The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current ROS client libraries, if applicable (roscpp, rospy, roslisp, etc...).
+
+While the term of this REP is still selected, the general structure can be thought of as follows, using ``TypeMasquerade`` in this case.
+
+  template<class From, class To>
+  struct TypeMapping
+  {
+    // This is where the conversion would occur
+  };
+
+  template<class From>
+  struct TypeMasquerade {
+    template<class To>
+    using as = TypeMapping<From, To>;
+  };
+
+Where there are four different tiers of how type masquerading could be expressed.
+
+The most explicit, could look like this::
+
+  using MsgT = rclcpp::TypeMasquerade<std_msgs::msg::String>::as<std::string>;
+  rclcpp::Publisher<MsgT>::SharedPtr publisher_;
+
+You would use this if you want it to be clear what is happening (maybe examples or depending on the preferences of the developer), or you might use it when `std::string` could map to more than one ROS type and you need to select which one to use.
+
+We could have a short form of this that takes two arguments::
+
+  rclcpp::Publisher<TypeMapping<std_msgs::msg::String, std::string>>::SharedPtr publisher_;
+
+Or this, but it might be prohibitively complicated to implement since there are multiple template arguments already for Publisher/Subscription::
+
+  rclcpp::Publisher<std_msgs::msg::String, std::string>::SharedPtr publisher_;
+
+Or you can be implicit::
+
+  rclcpp::Publisher<std::string>::SharedPtr publisher_;
+
+If ``std::string`` has multiple types it could represent then this has to error.
+
+
+Rationale
+=========
+
+  The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
+
+  The rationale should provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
+
+Putting it in ``rclcpp``
+------------------------
+
+It is thought that this should be put in the C++ client library for the following reasons:
+
+* Take advantage of C++'s templating system
+
+Picking a term
+---------------
+
+Goals
+"""""
+
+High priority:
+* Clearly communicate the that one type of term
+* Clearly communicate the order of the ROS and C++ arguments
+
+Low priority:
+* The C++ type should be on the left, so it is seen first
+* The order of the arguments shouldn't change in the two argument or one argument form
+
+Candidates
+""""""""""
+
+"Masquerade" and "Facade" are the two terms that have been discussed at length. Some pros and cons for these terms are as follows:
+
++------------+--------------------------------------------------------------+--------------------------------------------+
+| **Term**   | **Pros**                                                     | **Cons**                                   |
++------------+--------------------------------------------------------------+--------------------------------------------+
+| Masquerade | * Seems to be a common computer science concept,             | * An uncommon word that may be hard for    |
+|            |   for example <IP Masquerading in the Linux kernel           |   non-English and non-French speakers      |
+|            |   <http://linuxdocs.org/HOWTOs/IP-Masquerade-HOWTO-2.html>`_ |                                            |
+|            | * It is a verb, which perhaps makes it easier to discuss     |                                            |
++------------+--------------------------------------------------------------+--------------------------------------------+
+| Facade     | * Seems to be a common programming concept for extending     | * Isn't a verb, so perhaps this will make  |
+|            |   object oriented behavior [4]_                              |   it harder to talk about in discussions   |
+|            | * Seems to be in the public vernacular                       |                                            |
+|            | * More correct in an object oriented sense                   |                                            |
++------------+--------------------------------------------------------------+--------------------------------------------+
+
+We can also consider the anticipated usage for each of these terms:
+
++------------+----------------------------------------------------------+
+| **Term**   | **Usage**                                                |
++------------+----------------------------------------------------------+
+| Masquerade | ::                                                       |
+|            |                                                          |
+|            |   Masquerade<std_msgs::msg::String>::as<std::string>     |
+|            |                                                          |
+|            | or                                                       |
+|            |                                                          |
+|            | ::                                                       |
+|            |                                                          |
+|            |   Masquerade<std::string>::as<std_msgs::msg::String>     |
++------------+----------------------------------------------------------+
+| Facade     | ::                                                       |
+|            |                                                          |
+|            |   Facade<std::string>::instead_of<std_msgs::msg::String> |
++------------+----------------------------------------------------------+
+
+A major disadvantage of "Masquerade" is that it is not clear which of the two usages is more correct.
+Given a different perspective, both make sense.
+This confusion may result in frustration on the part of the ROS 2 developer:
+* frequently having to refer back to documentation
+* possibly opaque error messages
+
+While "Facade" does seem to be clearerd in terms of arguments, it has been pointed out the ``::instead_of`` syntax doesn't read well.
+In addition, the "Facade pattern" [4]_ seems to be more about simplifying an interface, where as in our case, we are proposing to convert one data type to another behind the scenes.
+
+
+Alternative choices
+"""""""""""""""""""
+
+Other possible suggestions (ranked by Audrow's opinion, with best at the top):
+* ``TypeAdapter<CppType>::to<RosType>``, follows Adapter pattern [6]_ - also most consistent with [3]_
+* ``TypeWrapper<CppType>::to<RosType>``
+* ``TypeMap<CppType>::to<RosType>``
+* ``TypeUse<CppType>::instead_of<RosType>``
+* ``TypeAccept<CppType>::as<RosType>``
+* ``TypeConvert<RosType>::to<CppType>``
+
+Suggested but discarded
+* Disguise: Discarded in favor of "Facade"
+* Decorate: Refers to the decorator pattern, which is not quite what we're doing here as our operations will occur at compile time, not run-time
+* Mask: Overloaded as a computer science term [5]_
+
+Prepending the word "Type"
+""""""""""""""""""""""""""
+
+Most of the terms being considered refer to a general design pattern and, thus, may be used in other ROS features.
+To reduce ambiguity, prefixing the term with "Type" would make its usage clearer and help avoid name collisions.
+
+
+Backwards Compatibility
+=======================
+
+  All REPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The REP must explain how the author proposes to deal with these incompatibilities. REP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+
+Reference Implementation
+========================
+
+  The reference implementation must be completed before any REP is given status "Final", but it need not be completed before the REP is accepted. It is better to finish the specification and rationale first and reach consensus on it before writing code.
+
+  The final implementation must include test code and documentation.
+
+  An example usage of references [1]_.
+
+
+References
+==========
+
+.. [1] REP 1, REP Purpose and Guidelines, Warsaw, Hylton
+   (https://ros.org/reps/rep-0001.html)
+.. [2] Masquerade, Merriam-Webster
+   (https://www.merriam-webster.com/dictionary/masquerade)
+.. [3] Adapting C++ Types
+   (http://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes#Adapting_C.2B-.2B-_Types)
+.. [4] Facade Pattern
+   (https://en.wikipedia.org/wiki/Facade_pattern)
+.. [5] Masking (computing)
+   (https://en.wikipedia.org/wiki/Mask_(computing))
+.. [6] Adapter pattern
+   (https://en.wikipedia.org/wiki/Adapter_pattern)
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -22,7 +22,7 @@ Motivation
   The motivation is critical for REPs that want to change the ROS APIs. It should clearly explain why the existing API specification is inadequate to address the problem that the REP solves. REP submissions without sufficient motivation may be rejected outright.
 
 The primary reason for this change is to improve the developer's experience working with ROS 2.
-Currently, a developer often has to write code to convert a ROS interface into another data structure for use.
+Currently, developers often write code to convert a ROS interface into another custom data structure for use in their programs.
 This can be trivial, in the case accessing the ``data`` field in ``std_msgs::msg::String``;
 or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type [1]_.
 Such conversions are additional work for the programmer and are potential sources of errors.
@@ -42,13 +42,14 @@ Specification
   The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current ROS client libraries, if applicable (roscpp, rospy, roslisp, etc...).
 
 There are different tiers of expressivity in the syntax for type adaptation, including both explicit to implicit forms.
-The explicit forms require the custom type and the ROS type to be specified; while the implicit form makes an assumption about the ROS type based on the custom type.
-The explicit forms could be used to clearly communicate what is happening, which may be useful in examples or tutorials, or may be used depending on the preferences of the developer.
+The explicit forms require the custom type and the ROS type to be specified; 
+while the implicit form makes an assumption about the ROS type based on the custom type.
+The explicit forms may be used to clearly communicate what is happening, which could be useful in examples or tutorials, or may be used depending on the preferences of the developer.
 While the implicit, and most concise, form will primarily be used for its convenience (although it lacks some of the functionality of the explicit forms).
 
 Below are examples of different syntaxes for type adaptation.
-In these examples and using the terminology above, ``std::string`` would be considered the custom type and the ROS interface ``std_msgs::msg::String`` would be considered the ROS type.
-Note that for every publisher created in the examples below, a ``std::string`` type variable (the custom type) would be adapted to be published on the ROS network as a ``std_msgs::msg::String`` (the ROS type).
+In these examples and using the terminology above, ``std::string`` will be considered the custom type and the ROS interface ``std_msgs::msg::String`` will be considered the ROS type.
+Note that, for every publisher created in the examples below, a ``std::string`` type variable (the custom type) would be adapted to be published on the ROS network as a ``std_msgs::msg::String`` (the ROS type).
 
 .. code-block:: cpp
 
@@ -68,14 +69,14 @@ The most explicit form could be shortened in the following to ways:
 
 Note that the 3rd explicit form may be prohibitively complicated to implement since there are multiple template arguments already for publishers and subscribers.
 
-The final shorthand, performs an implicit type adaptation with the custom type ``std::string`` which will be adapted to the ROS type``std_msgs::msg::String``:
+The final shorthand performs an implicit type adaptation with the custom type ``std::string`` which will be adapted to the ROS type``std_msgs::msg::String``:
 
 .. code-block:: cpp
 
    // Implicit Form
    rclcpp::Publisher<std::string>::SharedPtr publisher_4;
 
-In this final form, if ``std::string`` has multiple types it could represent, then an error will be raised during compilation.
+In this final form, if the custom type (``std::string``) has multiple ROS types that it could represent, then an error will be raised during compilation.
 
 
 Rationale
@@ -170,7 +171,7 @@ Here is a brief listing of additional terms that were considered and why they we
 
 :Decorate: Passed in favor of "Fascade", which seems to be more common.
 
-:Mask: Overloaded as a computer science term [6]_
+:Mask: Overloaded as a computer science term [6]_.
 
 :Map: Expresses the idea well, but has a lot of meanings in math and programming.
 
@@ -182,8 +183,9 @@ Here is a brief listing of additional terms that were considered and why they we
 Prepending the selected term with "Type"
 ----------------------------------------
 
-Most of the terms being considered refer to a general design pattern and, thus, may be used in other ROS features.
-To reduce ambiguity, prefixing the term with "Type" would make its usage clearer and help avoid name collisions and should make it easier for developers to find documentation.
+Most of the terms being considered refer to general design patterns and, thus, using just the pattern's name may cause naming collisions or confusion as those design patterns may be used in other parts of the ROS codebase. 
+To reduce ambiguity, prefixing the term selected with "Type" would make its usage clearer and help avoid name collisions;
+it should also make it easier for developers to find relevant documentation.
 
 
 Adding this feature in ``rclcpp``
@@ -191,7 +193,9 @@ Adding this feature in ``rclcpp``
 
 Placing this feature in ROS 2's C client library, ``rcl``, would allow this feature to be used in other client libraries, such as ``rclcpp`` and ``rclpy``.
 However, it is not clear that the difficulty of implementing this feature in ``rcl`` is worth the benefit to other client libraries.
-Placing this feature in ``rclcpp``, ROS 2's C++ client library, would allow implementation to take advantage of C++'s standard template library.
+The primary client library that is expected to use this feature is ROS 2's C++ client library, ``rclcpp``.
+Placing this feature in ``rclcpp`` would allow implementation to take advantage of C++'s standard template library, and thus, speed up development.
+
 
 Backwards Compatibility
 =======================

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -306,9 +306,27 @@ Adding this feature in ``rclcpp``
 ---------------------------------
 
 Placing this feature in ROS 2's C client library, ``rcl``, would allow this feature to be used in other client libraries, such as ``rclcpp`` and ``rclpy``.
-However, it is not clear that the difficulty of implementing this feature in ``rcl`` is worth the benefit to other client libraries.
-The primary client library that is expected to use this feature is ROS 2's C++ client library, ``rclcpp``.
-Placing this feature in ``rclcpp`` would allow implementation to take advantage of C++'s standard template library, and thus, speed up development.
+However, we believe that the concrete benefits for C++ currently outweigh the potential benefits for existing or theoretical client libraries in other languages.
+For example, placing this feature in ``rclcpp`` allows us to avoid type erasure (which would be necessary to place this functionality into ``rcl``) and to use ownership mechanics (unique and shared pointer) to ensure it is safely implemented.
+Another added advantage of placing this feature in ``rclcpp`` is that it reduce the number of function calls and calls that potentially are to functions in separate shared libraries.
+
+Perhaps we can support a form of this feature in other languages in ``rcl`` or ``rmw in the future.
+One challenge in doing this is that it may require custom type support, which may be middleware specific.
+This possibility will be further explored in the future.
+
+On the Location for Specifying the Type Adapter
+-----------------------------------------------
+
+In addition to being more convenient, specifying a type adapted type for the publisher at instantiation rather than in ``Publisher::publish`` allows the intra process system to be primed to expect a custom type.
+Similarly, it is preferable to specify the adapted type at instantiation for subscriptions, service clients, service servers, action clients, and action servers.
+
+Comparison to ROS 1's Type Adaptation
+-------------------------------------
+
+Although intended to be similar in functionality, the proposed feature and ROS 1's type adaptation support [5]_ have a few important differences:
+* This feature will support both convert and (de)serialize functions, and require at least one or the other, but also allow both. The reason for this is that convert is superior for intra-process communication and the (de)serialization functions are better for inter-process communication.
+* This feature will also require the user to write less code when creating an adapter, as compared to the ROS 1 implementation.
+* An advantage of following the ROS 1 approach is that an extra copy can be avoided; although it is likely much more challenging to implement this feature the ROS 1 way because of the middleware.
 
 
 Backwards Compatibility

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -50,7 +50,7 @@ Note that, for every publisher created in the examples below, a ``std::string`` 
 
    // Explicit Form 1: Most explicit
    using MsgT = rclcpp::AdaptType<std::string>::to<std_msgs::msg::String>;
-   auto pub = std::make_shared<rclcpp::Publisher<MsgT>>();
+   auto pub1 = std::make_shared<rclcpp::Publisher<MsgT>>();
 
 The most explicit form could be shortened in the following to ways:
 
@@ -58,10 +58,10 @@ The most explicit form could be shortened in the following to ways:
 
    // Explicit Form 2
    using MsgT = rclcpp::AdaptType<std::string, std_msgs::msg::String>;
-   auto pub = std::make_shared<rclcpp::Publisher<MsgT>>();
+   auto pub2 = std::make_shared<rclcpp::Publisher<MsgT>>();
 
    // Explicit Form 3
-   auto pub = std::make_shared<rclcpp::Publisher<std::string, std_msgs::msg::String>>();
+   auto pub3 = std::make_shared<rclcpp::Publisher<std::string, std_msgs::msg::String>>();
 
 Note that the 3rd explicit form may be prohibitively complicated to implement since there are multiple template arguments already for publishers and subscribers.
 
@@ -70,7 +70,7 @@ The final shorthand performs an implicit type adaptation with the custom type ``
 .. code-block:: cpp
 
    // Implicit Form
-   auto pub = std::make_shared<rclcpp::Publisher<std::string>>();
+   auto pub4 = std::make_shared<rclcpp::Publisher<std::string>>();
 
 In this final form, if the custom type (``std::string``) has multiple ROS types that it could represent, then an error will be raised during compilation.
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -11,15 +11,11 @@ Post-History: 28-Jan-2020
 Abstract
 ========
 
-  A short (~200 word) description of the technical issue being addressed.
-
 This REP proposes an extension to publishers and subscribers in `rclcpp` to make it easier to convert between ROS 2 interfaces and custom C++ data structures.
 
 
 Motivation
 ==========
-
-  The motivation is critical for REPs that want to change the ROS APIs. It should clearly explain why the existing API specification is inadequate to address the problem that the REP solves. REP submissions without sufficient motivation may be rejected outright.
 
 The primary reason for this change is to improve the developer's experience working with ROS 2.
 Currently, developers often write code to convert a ROS interface into another custom data structure for use in their programs.
@@ -36,10 +32,9 @@ Terminology
      ROS type (in code, ``RosType``)
        A data structure that *is* a ROS 2 interface, such as ``std_msgs::msg::String`` or ``sensor_msgs::msg::Image``.
 
+
 Specification
 =============
-
-  The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current ROS client libraries, if applicable (roscpp, rospy, roslisp, etc...).
 
 There are different tiers of expressivity in the syntax for type adaptation, including both explicit to implicit forms.
 The explicit forms require the custom type and the ROS type to be specified; 
@@ -82,8 +77,6 @@ In this final form, if the custom type (``std::string``) has multiple ROS types 
 
 Rationale
 =========
-
-  The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
 
 Selecting a term
 ----------------
@@ -201,19 +194,14 @@ Placing this feature in ``rclcpp`` would allow implementation to take advantage 
 Backwards Compatibility
 =======================
 
-  All REPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The REP must explain how the author proposes to deal with these incompatibilities. REP submissions without a sufficient backwards compatibility treatise may be rejected outright.
-
 The proposed feature adds new functionality while not modifying existing functionality.
 
 
 Reference Implementation
 ========================
 
-  The reference implementation must be completed before any REP is given status "Final", but it need not be completed before the REP is accepted. It is better to finish the specification and rationale first and reach consensus on it before writing code.
-
-  The final implementation must include test code and documentation.
-
 The current reference implementation is a work in progress and can be found `here <https://repl.it/@ros2/TypeMasquerading#audrow_main.cpp>`_.
+
 
 References
 ==========

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -54,7 +54,7 @@ Note that, for every publisher created in the examples below, a ``std::string`` 
 .. code-block:: cpp
 
    // Explicit Form 1: Most explicit
-   using MsgT = rclcpp::TypeAdapt<std::string>::to<std_msgs::msg::String>;
+   using MsgT = rclcpp::AdaptType<std::string>::to<std_msgs::msg::String>;
    rclcpp::Publisher<MsgT>::SharedPtr publisher1_;
 
 The most explicit form could be shortened in the following to ways:
@@ -62,7 +62,7 @@ The most explicit form could be shortened in the following to ways:
 .. code-block:: cpp
 
    // Explicit Form 2
-   rclcpp::Publisher<TypeAdapt<std::string, std_msgs::msg::String>>::SharedPtr publisher2_;
+   rclcpp::Publisher<AdaptType<std::string, std_msgs::msg::String>>::SharedPtr publisher2_;
 
    // Explicit Form 3
    rclcpp::Publisher<std::string, std_msgs::msg::String>::SharedPtr publisher_3;
@@ -180,11 +180,11 @@ Here is a brief listing of additional terms that were considered and why they we
 :Wrap: Passed in favor of "Adapt", which seems to be more common.
 
 
-Prepending the selected term with "Type"
-----------------------------------------
+Including "Type" in the name
+----------------------------
 
 Most of the terms being considered refer to general design patterns and, thus, using just the pattern's name may cause naming collisions or confusion as those design patterns may be used in other parts of the ROS codebase. 
-To reduce ambiguity, prefixing the term selected with "Type" would make its usage clearer and help avoid name collisions;
+To reduce ambiguity, including the term selected with "Type" would make its usage clearer and help avoid name collisions;
 it should also make it easier for developers to find relevant documentation.
 
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -11,7 +11,7 @@ Post-History: 28-Jan-2020
 Abstract
 ========
 
-This REP proposes an extension to publishers and subscribers in `rclcpp` to make it easier to convert between ROS 2 interfaces and custom C++ data structures.
+This REP proposes an extension to the creation of Publishers and Subscriptions in `rclcpp` to make it easier to convert between ROS 2 interfaces and custom C++ data structures.
 
 
 Motivation

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -55,17 +55,18 @@ Note that, for every publisher created in the examples below, a ``std::string`` 
 
    // Explicit Form 1: Most explicit
    using MsgT = rclcpp::AdaptType<std::string>::to<std_msgs::msg::String>;
-   rclcpp::Publisher<MsgT>::SharedPtr publisher1_;
+   auto pub = std::make_shared<rclcpp::Publisher<MsgT>>();
 
 The most explicit form could be shortened in the following to ways:
 
 .. code-block:: cpp
 
    // Explicit Form 2
-   rclcpp::Publisher<AdaptType<std::string, std_msgs::msg::String>>::SharedPtr publisher2_;
+   using MsgT = rclcpp::AdaptType<std::string, std_msgs::msg::String>;
+   auto pub = std::make_shared<rclcpp::Publisher<MsgT>>();
 
    // Explicit Form 3
-   rclcpp::Publisher<std::string, std_msgs::msg::String>::SharedPtr publisher_3;
+   auto pub = std::make_shared<rclcpp::Publisher<std::string, std_msgs::msg::String>>();
 
 Note that the 3rd explicit form may be prohibitively complicated to implement since there are multiple template arguments already for publishers and subscribers.
 
@@ -74,7 +75,7 @@ The final shorthand performs an implicit type adaptation with the custom type ``
 .. code-block:: cpp
 
    // Implicit Form
-   rclcpp::Publisher<std::string>::SharedPtr publisher_4;
+   auto pub = std::make_shared<rclcpp::Publisher<std::string>>();
 
 In this final form, if the custom type (``std::string``) has multiple ROS types that it could represent, then an error will be raised during compilation.
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -11,7 +11,7 @@ Post-History: 28-Jan-2020
 Abstract
 ========
 
-This REP proposes an extension to `rclcpp` that will make it easier to convert between ROS types and custom, user-defined types for topics, services, and action services.
+This REP proposes an extension to `rclcpp` that will make it easier to convert between ROS types and custom, user-defined types for Topics, Services, and Actions.
 
 
 Motivation
@@ -305,19 +305,19 @@ For example, "TypeAdapter" is perhaps more natural than "AdapterType".
 Adding this feature in ``rclcpp``
 ---------------------------------
 
-Placing this feature in ROS 2's C client library, ``rcl``, would allow this feature to be used in other client libraries, such as ``rclcpp`` and ``rclpy``.
+Placing this feature in ROS 2's client support library, ``rcl``, would allow this feature to be used in other client libraries, such as ``rclcpp`` and ``rclpy``.
 However, we believe that the concrete benefits for C++ currently outweigh the potential benefits for existing or theoretical client libraries in other languages.
 For example, placing this feature in ``rclcpp`` allows us to avoid type erasure (which would be necessary to place this functionality into ``rcl``) and to use ownership mechanics (unique and shared pointer) to ensure it is safely implemented.
 Another added advantage of placing this feature in ``rclcpp`` is that it reduce the number of function calls and calls that potentially are to functions in separate shared libraries.
 
-Perhaps we can support a form of this feature in other languages in ``rcl`` or ``rmw in the future.
+Perhaps we can support a form of this feature in other languages in ``rcl`` or ``rmw`` in the future.
 One challenge in doing this is that it may require custom type support, which may be middleware specific.
 This possibility will be further explored in the future.
 
 On the Location for Specifying the Type Adapter
 -----------------------------------------------
 
-In addition to being more convenient, specifying a type adapted type for the publisher at instantiation rather than in ``Publisher::publish`` allows the intra process system to be primed to expect a custom type.
+It was suggested that we only template the ``Publisher::publish`` method, but in addition to being more convenient, specifying a type adapter for the publisher at instantiation rather than in ``Publisher::publish`` allows the intra process system to be setup to expect a custom type.
 Similarly, it is preferable to specify the adapted type at instantiation for subscriptions, service clients, service servers, action clients, and action servers.
 
 Comparison to ROS 1's Type Adaptation

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -339,8 +339,19 @@ The proposed feature adds new functionality while not modifying existing functio
 Feature Progress
 ================
 
-The pull request `ros2/rclcpp#1557 <https://github.com/ros2/rclcpp/pull/1557>`_ implements the API for publishers and subscribers with the exception of the ``as`` syntax for defining a ``TypeAdapter`` specialization.
-Note that this pull request does not avoid converting the data during intraprocess communication.
+The type adaptation API has been implemented for publishers and subscribers (`ros2/rclcpp#1557 <https://github.com/ros2/rclcpp/pull/1557>`_). 
+Examples 
+(`ros2/examples#300 <https://github.com/ros2/examples/pull/300>`_)
+and demos 
+(`ros2/demos#482 <https://github.com/ros2/demos/pull/482>`_)
+for using type adaptation have also been created.
+
+There are several other features specified in this REP that have not been implemented. You can check the issues below to see the state of the reference implementation.
+
+* integrate into intra-process manager (`ros2/rclcpp#1664 <https://github.com/ros2/rclcpp/issues/1664>`_)
+* support serialize/deserialize functions in addition to the convert functions (`ros2/rclcpp#1665 <https://github.com/ros2/rclcpp/issues/1665>`_)
+* support services (`ros2/rclcpp#1666 <https://github.com/ros2/rclcpp/issues/1666>`_)
+* support actions (`ros2/rclcpp#1667 <https://github.com/ros2/rclcpp/issues/1667>`_)
 
 
 References

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -25,7 +25,7 @@ Such conversions are additional work for the programmer and are potential source
 
 An additional reason for this change is performance.
 This interface will allow us to define methods for serializing directly to the user requested type, and/or using that type in intra-process communication without ever converting it.
-Whereas without this feature, even to send a ``cv::Mat`` from one publisher to a subscription in the same process would require converting it to a ``sensor_msgs::msg::Image`` first and then back again to cv::Mat.
+Whereas without this feature, even to send a ``cv::Mat`` from one publisher to a subscription in the same process would require converting it to a ``sensor_msgs::msg::Image`` first and then back again to ``cv::Mat``.
 
 
 Terminology

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -31,10 +31,9 @@ Whereas without this feature, even to send a ``cv::Mat`` from one publisher to a
 Terminology
 ===========
 
-.. glossary::
-     Custom type (in code, ``CustomType``)
-       A data structure that *is not* a ROS 2 interface, such as ``std::string`` or ``cv::Mat``.
-     ROS type (in code, ``RosType``)
+:Custom type (in code, ``CustomType``):
+        A data structure that *is not* a ROS 2 interface, such as ``std::string`` or ``cv::Mat``.
+:ROS type (in code, ``RosType``):
        A data structure that *is* a ROS 2 interface, such as ``std_msgs::msg::String`` or ``sensor_msgs::msg::Image``.
 
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -23,6 +23,11 @@ This can be trivial, in the case accessing the ``data`` field in ``std_msgs::msg
 or more involved such when converting OpenCV's ``cv::Map`` to ROS's ``sensor_msgs/msg/Image`` type [1]_.
 Such conversions are additional work for the programmer and are potential sources of errors.
 
+An additional reason for this change is performance.
+This interface will allow us to define methods for serializing directly to the user requested type, and/or using that type in intra-process communication without ever converting it.
+Whereas without this feature, even to send a ``cv::Mat`` from one publisher to a subscription in the same process would require converting it to a ``sensor_msgs::msg::Image`` first and then back again to cv::Mat.
+
+
 Terminology
 ===========
 

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -243,27 +243,27 @@ It was thought to use "Facade" in the following form:
    Facade<std::string>::instead_of<std_msgs::msg::String>
 
 
-Adapt
-^^^^^
+Adapter
+^^^^^^^
 
-"Adapt" is certainly a common English word, and the "Adapter pattern" is a common design pattern for adjusting an interface [4]_, which matches well with the feature being suggested here.
-Also, using "Adapt" is consistent with the documentation of a similar feature in ROS 1 (i.e., "Adapting C++ Types" [5]_).
+"Adapter" is certainly a common English word, and the "Adapter pattern" is a common design pattern for adjusting an interface [4]_, which matches well with the feature being suggested here.
+Also, using "Adapter" is consistent with the documentation of a similar feature in ROS 1 (i.e., "Adapting C++ Types" [5]_).
 
-"Adapt" also has the advantage of being a verb and of being related to the noun "Adapter".
+"Adapter" also has the advantage of being a noun and of being related to the verb "Adapt".
 This flexiblity may make it easier for developers to discuss its use.
 
-"Adapt" could be used in the following syntax:
+"Adapter" could be used in the following syntax:
 
 .. code-block:: cpp
 
-   Adapt<std::string>::to<std_msgs::msg::String>
+   TypeAdapter<std::string>::as<std_msgs::msg::String>
 
 Additional terms considered
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Here is a brief listing of additional terms that were considered and why they were not selected:
 
-:Convert: Passed in favor of "Adapt", which expresses a similar idea and has a common design pattern.
+:Convert: Passed in favor of "Adapter", which expresses a similar idea and has a common design pattern.
 
 :Decorate: Passed in favor of "Fascade", which seems to be more common.
 
@@ -283,6 +283,8 @@ Most of the terms being considered refer to general design patterns and, thus, u
 To reduce ambiguity, including the term selected with "Type" would make its usage clearer and help avoid name collisions;
 it should also make it easier for developers to find relevant documentation.
 
+If the word "Type" should be appended or prepended to the selected term will largely be a matter of how it reads.
+For example, "TypeAdapter" is perhaps more natural than "AdapterType".
 
 Adding this feature in ``rclcpp``
 ---------------------------------

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -41,43 +41,140 @@ Terminology
 Specification
 =============
 
-There are different tiers of expressivity in the syntax for type adaptation, including both explicit to implicit forms.
-The explicit forms require the custom type and the ROS type to be specified; 
-while the implicit form makes an assumption about the ROS type based on the custom type.
-The explicit forms may be used to clearly communicate what is happening, which could be useful in examples or tutorials, or may be used depending on the preferences of the developer.
-While the implicit, and most concise, form will primarily be used for its convenience (although it lacks some of the functionality of the explicit forms).
+Defining a Type Adapter
+-----------------------
 
-Below are examples of different syntaxes for type adaptation.
-In these examples and using the terminology above, ``std::string`` will be considered the custom type and the ROS interface ``std_msgs::msg::String`` will be considered the ROS type.
-Note that, for every publisher created in the examples below, a ``std::string`` type variable (the custom type) would be adapted to be published on the ROS network as a ``std_msgs::msg::String`` (the ROS type).
+In order to adapt a custom type to a ROS type, the user must create a template specialization of this structure for the custom type.
+In that specialization they must:
 
-.. code-block:: cpp
+- change ``is_specialized`` to ``std::true_type``,
+- specify the custom type with ``using custom_type = ...``,
+- specify the ROS type with ``using ros_message_type = ...``,
+- provide static convert functions with the signatures:
+   - ``static void convert_to_ros(const custom_type &, ros_message_type &)``,
+   - ``static void convert_to_custom(const ros_message_type &, custom_type &)``
 
-   // Explicit Form 1: Most explicit
-   using MsgT = rclcpp::AdaptType<std::string>::to<std_msgs::msg::String>;
-   auto pub1 = std::make_shared<rclcpp::Publisher<MsgT>>();
+The convert functions must convert from one type to the other.
 
-The most explicit form could be shortened in the following ways:
-
-.. code-block:: cpp
-
-   // Explicit Form 2
-   using MsgT = rclcpp::AdaptType<std::string, std_msgs::msg::String>;
-   auto pub2 = std::make_shared<rclcpp::Publisher<MsgT>>();
-
-   // Explicit Form 3
-   auto pub3 = std::make_shared<rclcpp::Publisher<std::string, std_msgs::msg::String>>();
-
-Note that the 3rd explicit form may be prohibitively complicated to implement since there are multiple template arguments already for publishers and subscribers.
-
-The final shorthand performs an implicit type adaptation with the custom type ``std::string`` which will be adapted to the ROS type``std_msgs::msg::String``:
+For example, here is a theoretical example for adapting ``std::string`` to the ``std_msgs::msg::String`` ROS message type:
 
 .. code-block:: cpp
 
-   // Implicit Form
-   auto pub4 = std::make_shared<rclcpp::Publisher<std::string>>();
+   template<>
+   struct rclcpp::TypeAdapter<
+      std::string,
+      std_msgs::msg::String
+   >
+   {
+     using is_specialized = std::true_type;
+     using custom_type = std::string;
+     using ros_message_type = std_msgs::msg::String;
 
-In this final form, if the custom type (``std::string``) has multiple ROS types that it could represent, then an error will be raised during compilation.
+     static
+     void
+     convert_to_ros_message(
+       const custom_type & source,
+       ros_message_type & destination)
+     {
+       destination.data = source;
+     }
+
+     static
+     void
+     convert_to_custom(
+       const ros_message_type & source,
+       custom_type & destination)
+     {
+       destination = source.data;
+     }
+   };
+
+Type Adaptation in Topics
+-------------------------
+
+The adapter can then be used when creating a publisher or subscription, e.g.:
+
+.. code-block:: cpp
+
+   using MyAdaptedType = TypeAdapter<std::string, std_msgs::msg::String>;
+   auto pub = node->create_publisher<MyAdaptedType>("topic", 10);
+   auto sub = node->create_subscription<MyAdaptedType>(
+     "topic",
+     10,
+     [](const std::string & msg) {...});
+
+You can also be more declarative by using the ``adapt_type::as`` metafunctions, which are a bit less ambiguous to read:
+
+.. code-block:: cpp
+
+   using AdaptedType = rclcpp::adapt_type<std::string>::as<std_msgs::msg::String>;
+   auto pub = node->create_publisher<AdaptedType>(...);
+
+If you wish, you may associate a custom type with a single ROS message type, allowing you to be a bit more brief when creating entities, e.g.:
+
+.. code-block:: cpp
+
+   // First you must declare the association, this is similar to how you
+   // would avoid using the namespace in C++ by doing `using std::vector;`.
+   RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(std::string, std_msgs::msg::String);
+
+   // Then you can create things with just the custom type, and the ROS
+   // message type is implied based on the previous statement.
+   auto pub = node->create_publisher<std::string>(...);
+
+Type Adaptation in Services
+---------------------------
+
+Type adaptation can be used with a client and service by creating a ``struct`` that defines a type adapter for the request and the response. For example:
+
+.. code-block:: cpp
+
+   using MyAdaptedRequestType = TypeAdapter<std::string, std_msgs::msg::String>;
+   using MyAdaptedResponseType = TypeAdapter<bool, std_msgs::msg::Bool>;
+
+   struct MyServiceTypeAdapter {
+      using Request = MyAdaptedRequestType;
+      using Response = MyAdaptedResponseType;
+   };
+
+   auto client = node->create_client<MyServiceTypeAdapter>("service");
+   auto service = node->create_service<MyServiceTypeAdapter>(
+     "service",
+     [](const std::string & request) {...});
+
+Similarly, either the request or response can be adapted:
+
+.. code-block:: cpp
+
+   using MyAdaptedRequestType = TypeAdapter<bool, std_msgs::msg::Bool>;
+
+   struct MySetBoolTypeAdapter {
+      using Request = MyAdaptedRequestType;
+      using Response = std_srvs::srv::SetBool::Response;
+   };
+
+Type Adaptation in Actions
+--------------------------
+
+Similar to services, type adaptation can be used with action clients and action services by creating a ``struct`` that defines a type adapter for the request, feedback, and result.
+As with services, the ROS type for a request, feedback, or result can be specified for use in this structure as well.
+
+.. code-block:: cpp
+
+   struct MyActionTypeAdapter {
+      using Goal = MyAdaptedGoalType;
+      using Feedback = MyAdaptedFeedbackType;
+      using Result = MyAdaptedResultType;
+   };
+
+   auto node = rclcpp::Node::make_shared("action_node");
+   auto action_client = rclcpp_action::create_client<MyActionTypeAdapter>(node, "action");
+   auto action_server = rclcpp_action::create_server<MyActionTypeAdapter>(
+     node,
+     "action",
+     handle_goal,
+     handle_cancel,
+     handle_accepted);
 
 
 Rationale

--- a/rep-2007.rst
+++ b/rep-2007.rst
@@ -2,7 +2,7 @@ REP: 2007
 Title: Adapting C++ Types
 Author: Audrow Nash <audrow@openrobotics.org>
 Status: Active
-Type: Standard
+Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Jan-2020
 Post-History: 28-Jan-2020


### PR DESCRIPTION
Adds a REP for supporting type adaptation (a.k.a. Type Masquerading) in `rclcpp`.

----

References and related links:

- rclcpp pull request:
  - https://github.com/ros2/rclcpp/pull/1557
- Aspirational examples and demos:
  - https://github.com/ros2/examples/pull/300
  - https://github.com/ros2/demos/pull/482
- Scratch pad for prototyping the technical mechanics for how this will work:
  - https://repl.it/@wjwwood/HarmoniousQuaintWorkers#main.cpp (or the repository [here](https://github.com/audrow/MockingRosTypeAdapter))
  - older one: https://github.com/audrow/TypeAdaptation