### PR TITLE
Adds diagnostic aggregator to REP 2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -312,6 +312,7 @@ All items on the list for the next distro should already be released into the ro
 
 * Features
 
+  * `diagnostics/diagnostic_aggregator <https://index.ros.org/p/diagnostic_aggregator/>`_
   * `diagnostics/diagnostic_updater <https://index.ros.org/p/diagnostic_updater/>`_
   * `diagnostics/self_test <https://index.ros.org/p/self_test/>`_
   * `joint_state_publisher/joint_state_publisher <https://index.ros.org/p/joint_state_publisher/>`_


### PR DESCRIPTION
This is a proposal to add the [diagnostic aggregator](https://index.ros.org/p/diagnostic_aggregator/) to the REP 2005 common packages definition.
The diagnostic updater and self test are already part of REP2005 and usually go together with the diagnostic aggregator in a common diagnostic setup.

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>