### PR TITLE
Rolling now targets the same platfroms as Galactic

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -835,7 +835,7 @@ Rolling Ridley (June 2020 - Ongoing)
 Rolling Ridley is a rolling development distribution of ROS 2 as described in REP-2002 [8]_.
 
 The target platform for Rolling Ridley will update as new upstream distributions are selected for ROS 2 development.
-As of June 2020, Rolling Ridley targets the same platforms as ROS 2 Foxy Fitzroy.
+As of March 2021, Rolling Ridley targets the same platforms as ROS 2 Galactic Geochelone.
 
 
 Motivation


### PR DESCRIPTION
...which is different from the platforms targeted by Foxy.