### PR TITLE
Adding 2 new Nav2 packages to REP 2005

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -361,7 +361,9 @@ All items on the list for the next distro should already be released into the ro
     * `navigation2/nav2_navfn_planner <https://index.ros.org/p/nav2_navfn_planner/>`_
     * `navigation2/nav2_planner <https://index.ros.org/p/nav2_planner/>`_
     * `navigation2/nav2_recoveries <https://index.ros.org/p/nav2_recoveries/>`_
+    * `navigation2/nav2_regulated_pure_pursuit_controller <https://index.ros.org/p/nav2_regulated_pure_pursuit_controller/>`_
     * `navigation2/nav2_rviz_plugins <https://index.ros.org/p/nav2_rviz_plugins/>`_
+    * `navigation2/nav2_smac_planner <https://index.ros.org/p/nav2_smac_planner/>`_
     * `navigation2/nav2_system_tests <https://index.ros.org/p/nav2_system_tests/>`_
     * `navigation2/nav2_util <https://index.ros.org/p/nav2_util/>`_
     * `navigation2/nav2_voxel_grid <https://index.ros.org/p/nav2_voxel_grid/>`_


### PR DESCRIPTION
The Regulated Pure Pursuit controller enables differential and ackermann steering robots to accurately track backs better than Adaptive Pure Pursuit and nominal Pure Pursuit. It does so without dynamic collision avoidance, a relatively common request among users.

The Smac planner enables Hybrid-A* and soon to be State Lattice planning to allow for kinematically feasible paths to be calculated in real-time to handle non-circular robots utilizing the extents of their proper drivetrains. 