### PR TITLE
[rep-0151] rst not rendering Python shebang code, which is crucial in the context.

### DIFF
--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -207,7 +207,7 @@ Python 3 equivalents.
 Packages using the same code base for multiple ROS distros should instead use
 conditional dependencies as described in REP 149 [5]_.
 
-.. code-block: xml
+.. code-block:: xml
 
     <depend condition="$ROS_PYTHON_VERSION == '2'">python-numpy</depend>
     <depend condition="$ROS_PYTHON_VERSION == '3'">python3-numpy</depend>

--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -175,7 +175,7 @@ Shebangs and reliance on the Python command
 '''''''''''''''''''''''''''''''''''''''''''
 Python scripts on UNIX systems typically have shebang lines written as:
 
-  .. code-block:: python
+.. code-block:: bash
 
     #!/usr/bin/env python
 

--- a/rep-0151.rst
+++ b/rep-0151.rst
@@ -175,7 +175,7 @@ Shebangs and reliance on the Python command
 '''''''''''''''''''''''''''''''''''''''''''
 Python scripts on UNIX systems typically have shebang lines written as:
 
-.. code-block: bash
+  .. code-block:: python
 
     #!/usr/bin/env python
 


### PR DESCRIPTION
Without this change, `shebang` is invisible. Showing how `shebang` looks like seems to be critical in the very context.

Problematic rendering can be seen at [Shebangs and reliance on the Python command](https://www.ros.org/reps/rep-0151.html#shebangs-and-reliance-on-the-python-command) section.