### PR TITLE
Update the Galactic EOL date to November 2022.

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -716,8 +716,8 @@ Build System Support:
 - cmake
 - setuptools
 
-Galactic Geochelone (May 2021 - May 2022)
------------------------------------------
+Galactic Geochelone (May 2021 - November 2022)
+----------------------------------------------
 
 Targeted platforms:
 


### PR DESCRIPTION
That's what we promised in the Release Schedule on top, so we
should honor that.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>