### PR TITLE
Add rclc to desktop variant

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -93,7 +93,7 @@ It provides all commonly used libraries as well as visualization tools and tutor
       extends: [ros_base]
       packages: [angles, demos, depthimage_to_laserscan, example_interfaces,
                  examples, joystick_drivers, laser_geometry,
-                 navigation_msgs, pcl_conversions, realtime_support,
+                 navigation_msgs, pcl_conversions, rclc, realtime_support,
                  resource_retriever, rviz, teleop_twist_joy,
                  teleop_twist_keyboard, tlsf, turtlesim, vision_opencv]
 


### PR DESCRIPTION
In context of micro-ROS, we (primarily @JanStaschulat and @pablogs9) have been working intensively on making rclc (in combination with rcl) an almost feature-complete client library for the C programming language. We have also worked a lot on quality assurance and achieved Quality Level 2. Although rclc was developed for microcontrollers, we think it is also of high value for ROS 2 in general and therefore want to add it to the desktop variant. Is the Galactic release a good point in time to include rclc in the desktop variant? Or should it be added afterwards?
Note: If this PR is accepted, I'll open a corresponding PR on https://github.com/ros2/variants