### PR TITLE
Replace removed cgi.escape with html.escape.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
     build:
       name: run rep tests
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
 
       steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{matrix.python}}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install docutils xmlschema

--- a/rep2html.py
+++ b/rep2html.py
@@ -39,7 +39,7 @@ from __future__ import print_function
 import sys
 import os
 import re
-import cgi
+import html
 import glob
 import getopt
 import errno
@@ -124,8 +124,8 @@ def fixanchor(current, match):
         rfcnum = int(match.group('rfcnum'))
         link = RFCURL % rfcnum
     if link:
-        return '<a href="%s">%s</a>' % (cgi.escape(link), cgi.escape(text))
-    return cgi.escape(match.group(0))  # really slow, but it works...
+        return '<a href="%s">%s</a>' % (html.escape(link, quote=False), html.escape(text, quote=False))
+    return html.escape(match.group(0), quote=False)  # really slow, but it works...
 
 
 NON_MASKED_EMAILS = [
@@ -246,18 +246,18 @@ def fixfile(inpath, input_lines, outfile):
                                       time.localtime(os.stat(inpath)[8]))
             try:
                 url = REPGITURL % int(rep)
-                v = '<a href="%s">%s</a> ' % (url, cgi.escape(date))
+                v = '<a href="%s">%s</a> ' % (url, html.escape(date, quote=False))
             except ValueError as error:
                 v = date
         elif k.lower() in ('content-type',):
             url = REPURL % 9
             rep_type = v or 'text/plain'
-            v = '<a href="%s">%s</a> ' % (url, cgi.escape(rep_type))
+            v = '<a href="%s">%s</a> ' % (url, html.escape(rep_type, quote=False))
         else:
-            v = cgi.escape(v)
+            v = html.escape(v, quote=False)
         print(('  <tr class="field"><th class="field-name">%s:&nbsp;</th>' +
                '<td class="field-body">%s</td></tr>') %
-              (cgi.escape(k), v), file=outfile)
+              (html.escape(k, quote=False), v), file=outfile)
     print('</table>', file=outfile)
     print('</div>', file=outfile)
     print('<hr />', file=outfile)

--- a/rep2html.py
+++ b/rep2html.py
@@ -124,8 +124,8 @@ def fixanchor(current, match):
         rfcnum = int(match.group('rfcnum'))
         link = RFCURL % rfcnum
     if link:
-        return '<a href="%s">%s</a>' % (html.escape(link, quote=False), html.escape(text, quote=False))
-    return html.escape(match.group(0), quote=False)  # really slow, but it works...
+        return '<a href="%s">%s</a>' % (html.escape(link), html.escape(text))
+    return html.escape(match.group(0))  # really slow, but it works...
 
 
 NON_MASKED_EMAILS = [
@@ -246,18 +246,18 @@ def fixfile(inpath, input_lines, outfile):
                                       time.localtime(os.stat(inpath)[8]))
             try:
                 url = REPGITURL % int(rep)
-                v = '<a href="%s">%s</a> ' % (url, html.escape(date, quote=False))
+                v = '<a href="%s">%s</a> ' % (url, html.escape(date))
             except ValueError as error:
                 v = date
         elif k.lower() in ('content-type',):
             url = REPURL % 9
             rep_type = v or 'text/plain'
-            v = '<a href="%s">%s</a> ' % (url, html.escape(rep_type, quote=False))
+            v = '<a href="%s">%s</a> ' % (url, html.escape(rep_type))
         else:
-            v = html.escape(v, quote=False)
+            v = html.escape(v)
         print(('  <tr class="field"><th class="field-name">%s:&nbsp;</th>' +
                '<td class="field-body">%s</td></tr>') %
-              (html.escape(k, quote=False), v), file=outfile)
+              (html.escape(k), v), file=outfile)
     print('</table>', file=outfile)
     print('</div>', file=outfile)
     print('<hr />', file=outfile)


### PR DESCRIPTION
[cgi.escape](https://docs.python.org/3.7/library/cgi.html#cgi.escape) was removed in Python 3.8 after being deprecated since it does not escape quotes by default and is therefore considered unsafe. In order to preserve the current behavior I've added [html.escape](https://docs.python.org/3.7/library/html.html#html.escape) with quote=False in order to match exactly the old behavior and then switched to the default behavior and compared the two.


```diff
--- quote-false/rep-0000.html   2021-05-17 15:38:13.745754117 -0700
+++ quote-true/rep-0000.html    2021-05-17 15:40:07.775869644 -0700
@@ -352,7 +352,7 @@
     Meeussen, Wim
     Mihelich, Patrick                                mihelich&#32;&#97;t&#32;willowgarage.com
     Moulard, Thomas                                  thomas.moulard&#32;&#97;t&#32;gmail.com
-    O'Quin, Jack
+    O&#x27;Quin, Jack
     Purvis, Mike
     Rabaud, Vincent                                  vincent.rabaud&#32;&#97;t&#32;gmail.com
     Ragnarok, Steven!                                steven&#32;&#97;t&#32;openrobotics.org
```

Since there's only a single character difference between the current output and it is in a display setting I've opted to use html.escape's new default for this PR.