### PR TITLE
Update REP-2005 MoveIt Packages

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -389,12 +389,10 @@ All items on the list for the next distro should already be released into the ro
     * `moveit2/moveit_ros_visualization <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_ros_benchmarks <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_ros_planning_interface <https://github.com/ros-planning/moveit2/>`_
-    * `moveit2/moveit_fake_controller_manager <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_simple_controller_manager <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_plugins <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_ros_control_interface <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_planners_ompl <https://github.com/ros-planning/moveit2/>`_
-    * `moveit2/moveit_planners_trajopt <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_planners <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_chomp_optimizer_adapter <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/chomp_motion_planner <https://github.com/ros-planning/moveit2/>`_
@@ -403,6 +401,7 @@ All items on the list for the next distro should already be released into the ro
     * `moveit2/moveit_runtime <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit <https://github.com/ros-planning/moveit2/>`_
     * `moveit2/moveit_kinematics <https://github.com/ros-planning/moveit2/>`_
+    * `moveit2/pilz_industrial_motion_planner <https://index.ros.org/p/pilz_industrial_motion_planner/>`_
 
   * `cra-ros-pkg/robot_localization <https://github.com/cra-ros-pkg/robot_localization/>`_
   * `interactive_markers/interactive_markers <https://index.ros.org/p/interactive_markers/>`_


### PR DESCRIPTION
Remove outdated packages:
 - moveit2/moveit_fake_controller_manager which has moved into ros2_control

And to add a new package:
 - moveit2/pilz_industrial_motion_planner, a new motion planner