### PR TITLE
REP-2001: Desktop-full, perception and simulation variants for ROS 2 

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -35,10 +35,8 @@ End-user entry points
 
 We define various entry points for ROS users.
 
- * `desktop_full` (recommended from Humble): The `desktop_full` variant is the main entry point for new users.
-   It provides a "batteries included" experience, enabling novice users to complete most entry
-   tutorials without knowledge of the underlying library structure.
- * `desktop` (recommended until Galactic): The `desktop` variant provides all commonly used libraries as well as
+ * `desktop_full` (available from Humble): The `desktop_full` variant provides a "batteries included" experience, enabling novice users to complete most entry tutorials without knowledge of the underlying library structure.
+ * `desktop` (recommended): The `desktop` variant provides all commonly used libraries as well as
    visualization tools and tutorials.
  * `ros_base`: The `ros_base` variant composes the `ros_core` metapackage with commonly used libraries.
    It may not contain any GUI dependencies.

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -35,14 +35,14 @@ End-user entry points
 
 We define four main entry points for ROS users.
 
- * `desktop_full` (recommended from Humble): The `desktop_full` metapackage is the main entry point for users.
+ * `quickstart` (recommended from Humble): The `quickstart` variant is the main entry point for new users.
    It provides a "batteries included" experience, enabling novice users to complete most entry
    tutorials without knowledge of the underlying library structure.
- * `desktop` (recommended until Galactic): The `desktop` provides all commonly used libraries as well as
+ * `desktop` (recommended until Galactic): The `desktop` variant provides all commonly used libraries as well as
    visualization tools and tutorials.
- * `ros_base`: The `ros_base` metapackage composes the `ros_core` metapackage with commonly used libraries.
+ * `ros_base`: The `ros_base` variant composes the `ros_core` metapackage with commonly used libraries.
    It may not contain any GUI dependencies.
- * `ros_core`: The `ros_core` variants composes the core communication protocols.
+ * `ros_core`: The `ros_core` variant composes the core communication protocols.
    It may not contain any GUI dependencies.
 
 
@@ -655,16 +655,16 @@ Simulation
 
   - simulation:
       extends:  [ros_base]
-      packages: [ros_ign]
+      packages: [ros_ign_bridge, ros_ign_gazebo, ros_ign_image, ros_ign_interfaces]
 
-Desktop Full
+Quick Start
 """"""""""
 
 ::
 
-  - desktop_full:
+  - quickstart:
       extends:  [desktop]
-      packages: [perception, simulation]
+      packages: [perception, simulation, ros_ign_gazebo_demos]
 
 
 References

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -33,7 +33,7 @@ Specification
 End-user entry points
 ---------------------
 
-We define four main entry points for ROS users.
+We define various entry points for ROS users.
 
  * `quickstart` (recommended from Humble): The `quickstart` variant is the main entry point for new users.
    It provides a "batteries included" experience, enabling novice users to complete most entry
@@ -44,6 +44,9 @@ We define four main entry points for ROS users.
    It may not contain any GUI dependencies.
  * `ros_core`: The `ros_core` variant composes the core communication protocols.
    It may not contain any GUI dependencies.
+ * `perception`: The `perception` variant includes packages commonly used for perception capabilities.
+ * `simulation`: The `simulation` variant includes packages that are needed for automated simulation,
+   without extra debugging tools.
 
 
 Institution-specific and robot-specific

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -35,7 +35,7 @@ End-user entry points
 
 We define various entry points for ROS users.
 
- * `quickstart` (recommended from Humble): The `quickstart` variant is the main entry point for new users.
+ * `desktop_full` (recommended from Humble): The `desktop_full` variant is the main entry point for new users.
    It provides a "batteries included" experience, enabling novice users to complete most entry
    tutorials without knowledge of the underlying library structure.
  * `desktop` (recommended until Galactic): The `desktop` variant provides all commonly used libraries as well as
@@ -660,12 +660,12 @@ Simulation
       extends:  [ros_base]
       packages: [ros_ign_bridge, ros_ign_gazebo, ros_ign_image, ros_ign_interfaces]
 
-Quick Start
+Desktop Full
 """"""""""
 
 ::
 
-  - quickstart:
+  - desktop_full:
       extends:  [desktop]
       packages: [perception, simulation, ros_ign_gazebo_demos]
 

--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -33,13 +33,16 @@ Specification
 End-user entry points
 ---------------------
 
-We define three main entry points for ROS users.
+We define four main entry points for ROS users.
 
- * desktop (recommended): The `desktop` metapackage is the main entry point for users.
-   It provides all commonly used libraries as well as visualization tools and tutorials.
- * ros_base: The `ros_base` metapackage composes the `ros_core` metapackage with commonly used libraries.
+ * `desktop_full` (recommended from Humble): The `desktop_full` metapackage is the main entry point for users.
+   It provides a "batteries included" experience, enabling novice users to complete most entry
+   tutorials without knowledge of the underlying library structure.
+ * `desktop` (recommended until Galactic): The `desktop` provides all commonly used libraries as well as
+   visualization tools and tutorials.
+ * `ros_base`: The `ros_base` metapackage composes the `ros_core` metapackage with commonly used libraries.
    It may not contain any GUI dependencies.
- * ros_core: The `ros_core` variants composes the core communication protocols.
+ * `ros_core`: The `ros_core` variants composes the core communication protocols.
    It may not contain any GUI dependencies.
 
 
@@ -633,6 +636,35 @@ Desktop
                  rviz2, rviz_default_plugins, teleop_twist_joy,
                  teleop_twist_keyboard, tlsf, tlsf_cpp,
                  topic_monitor, turtlesim]
+
+Perception
+""""""""""
+
+::
+
+  - perception:
+      extends:  [ros_base]
+      packages: [image_common, image_pipeline, image_transport_plugins,
+                 laser_filters, laser_geometry, perception_pcl,
+                 vision_opencv]
+
+Simulation
+""""""""""
+
+::
+
+  - simulation:
+      extends:  [ros_base]
+      packages: [ros_ign]
+
+Desktop Full
+""""""""""
+
+::
+
+  - desktop_full:
+      extends:  [desktop]
+      packages: [perception, simulation]
 
 
 References


### PR DESCRIPTION
There's a gap in the variants provided by ROS 1 and ROS 2. This PR adds the `perception`, `simulators` and `desktop-full` variants (see [REP-108: desktop variants](https://www.ros.org/reps/rep-0108.html#desktop-variants) and [REP-150: desktop variants](https://ros.org/reps/rep-0150.html#desktop-variants)).

I tried my best to match the ROS 1 variants, as I believe that's what users would expect. But we don't need to strictly follow ROS 1 and should adapt to ROS 2's needs as appropriate. Therefore I'd appreciate feedback on whether we should add or remove packages to the lists on this PR.

Here's a collection of ROS 1 resources:

* [REP-108](https://www.ros.org/reps/rep-0108.html#desktop-variants) (From Diamondback)
    * `perception`
        * `[image_common, image_transport_plugins, image_pipeline, laser_pipeline, perception_pcl, vision_opencv]`
    * `simulators`
        * `[simulator_stage, simulator_gazebo, physics_ode, visualization_common, rx]`
    * `desktop-full`
        * `[desktop, mobile, perception, simulators]`

* [REP-150](https://ros.org/reps/rep-0150.html#desktop-variants) (From Melodic)
    * Matches [ros/metapackages noetic-devel branch](https://github.com/ros/metapackages/tree/noetic-devel)
    * `perception`
        * `[image_common, image_pipeline, image_transport_plugins, laser_pipeline, perception_pcl, vision_opencv]`
        * No change from REP-108
    * `simulators`
        * `[gazebo_ros_pkgs, rqt_common_plugins, rqt_robot_plugins, stage_ros]`
        * Several changes from REP-108
    * `desktop-full`
        * `[desktop, perception, simulators]`
        * Dropped `mobile`, added `urdf_sim_tutorial`
---

Based on the above, here's the proposal for ROS 2:

### perception

Package | Reason
--- | ---
image_common | REP-108 / REP-150
image_pipeline | REP-108 / REP-150
image_transport_plugins | REP-108 / REP-150
laser_pipeline | REP-108 / REP-150 - Not available on ROS 2 (yet?) broken into the [dependencies](https://github.com/ros-perception/laser_pipeline/blob/eb2d1369f77d1bea94f7ddd651cefb9c135560a5/package.xml#L15-L17) available below
laser_filters | Part of `laser_pipeline` on ROS 1
laser_geometry | Part of `laser_pipeline` on ROS 1
perception_pcl | REP-108 / REP-150
vision_opencv | REP-108 / REP-150

### simulators

I'm proposing on this PR that we change the name from `simulators` to `simulation` to be more generic.

Package | Reason
--- | ---
gazebo_ros_pkgs | Included `ros_ign` instead, which is the latest generation of Gazebo-ROS integration
ros_ign | Included instead of `gazebo_ros_pkgs`
rqt_common_plugins | Already part of `desktop`, removed because it's not strictly simulation-related
rqt_robot_plugins | Not on ROS 2, not simulation related, removed
stage_ros | No ROS 2 integration

### desktop-full

It's been brought up that this is not a great name for a variant. I'm not completely sold on `desktop-full`, but it does have the advantage of being a name that's known among ROS 1 users.

Package | Reason
--- | ---
desktop | REP-150
perception | REP-150
simulators | REP-150, renamed to `simulation`
urdf_sim_tutorial | Not on ROS 2 (yet?)

---

* See implementation in https://github.com/ros2/variants/pull/34
