### PR TITLE
New attributes for license tag

### DIFF
--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Oct-2017
-Post-History: 02-Jan-2018, 31-Aug-2020
+Post-History: 02-Jan-2018, 31-Aug-2020, 04-Apr-2022
 
 Outline
 =======
@@ -346,8 +346,8 @@ Example
     </description>
     <maintainer email="someone@example.com">Someone</maintainer>
 
-    <license>BSD</license>
-    <license file="LICENSE">LGPL</license>
+    <license file="LICENSE">BSD-3-Clause</license>
+    <license source-files="include/my_package/linear_math/*">Zlib</license>
 
     <url type="website">http://wiki.ros.org/my_package</url>
     <url type="repository">http://www.github.com/my_org/my_package</url>
@@ -465,32 +465,18 @@ Example
 <license> (multiple, but at least one)
 --------------------------------------
 
-Name of license for this package, e.g. BSD, GPL, LGPL.  In order to
-assist machine readability, only include the license name in this tag.
-For multiple licenses multiple separate tags must be used.  A package
-will have multiple licenses if different source files have different
-licenses.  Every license occurring in the source files should have
-a corresponding ``<license>`` tag.  For any explanatory text about
-licensing caveats, please use the ``<description>`` tag.
-
-Most common open-source licenses are described on the
-`OSI website <http://www.opensource.org/licenses/alphabetical>`_.
-
-Commonly used license strings:
-
- - Apache-2.0
- - BSD
- - Boost Software License
- - GPLv2
- - GPLv3
- - LGPLv2.1
- - LGPLv3
- - MIT
- - Mozilla Public License Version 1.1
+Name of license for this package or selected files of this package,
+e.g. BSD-3-Clause, GPL-3.0-or-later, Apache-2.0. In order to assist
+machine readability, only include the `SPDX license identifier
+<https://spdx.org/licenses/>`_ in this tag. In the rare case that
+a package (or selected source files of the package) are licensed under
+multiple alternative licenses, the identifiers can be combined by
+``or`` as described in Section 7.2 of the `Machine-readable
+debian/copyright file specification V1.0
+<https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/>`_.
 
 Attributes
 ''''''''''
-
   .. raw:: html
 
     <font color="blue">
@@ -504,6 +490,22 @@ Attributes
   E.g. the ``Apache License, Version 2.0`` states in paragraph 4.1:
   
     "You must give any other recipients of the Work or Derivative Works a copy of this License"
+
+ ``source-files="FILENAME-PATTERN"`` *(optional)*
+
+  A filename pattern using the simplified shell glob syntax specified in Section 6.9 of the `Machine-readable
+  debian/copyright file specification V1.0 <https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/>`_
+  and relative to the ``package.xml`` file.
+
+  The filename pattern specifies the source files this license information refers to. The value
+  ``source-files="*"`` refers to all source files of the package, including source files that are downloaded automatically
+  during the build process - for example in the case of so-called *vendor packages*. If the attribute is not specified,
+  the tag again refers to all source files of the package, including downloaded source files.
+
+  If the filename patterns of multiple license tags match a particular file, the last tag applies to it - following
+  the logic described in Section 6.9 of the `Machine-readable
+  debian/copyright file specification V1.0 <https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/>`_.
+  Consequently, more general tags should be given first.
 
   .. raw:: html
 

--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -519,6 +519,20 @@ Attributes
 
     </font>
 
+Notes
+'''''
+
+The license information given in the license tags has to be consistent
+with the information given in the license headers of the source files.
+This may be checked by suitable linting tools.
+
+Furthermore, by the license tags in the ``package.xml`` file and the
+copyright information obtained from the license headers of the source files
+(e.g., using ``licensecheck --copyright``)
+a copyright file according to the `Machine-readable debian/copyright file
+specification V1.0 <https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/>`_
+for binary versions of this package can be created automatically.
+
 <url> (multiple)
 ----------------
 

--- a/rep-0149.rst
+++ b/rep-0149.rst
@@ -5,7 +5,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Oct-2017
-Post-History: 02-Jan-2018, 31-Aug-2020, 04-Apr-2022
+Post-History: 02-Jan-2018, 31-Aug-2020, 14-Apr-2022
 
 Outline
 =======
@@ -506,6 +506,14 @@ Attributes
   the logic described in Section 6.9 of the `Machine-readable
   debian/copyright file specification V1.0 <https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/>`_.
   Consequently, more general tags should be given first.
+
+ ``copyright="COPYRIGHT HOLDER INFORMATION"`` *(optional)*
+
+  Information about copyright holders of the source files this tag refers to. The attribute value is considered in addition to the
+  copyright information given in the license headers of those source files. In case of normal source files with proper license header
+  this attribute is not required. It is particularly intended for vendor packages, which download the source code during
+  the build process from another repository, i.e., where the actual source files are not stored in the current repository
+  and thus not available to tools that analyze the source code of the current package only.
 
   .. raw:: html
 


### PR DESCRIPTION
... as basis for automatic creation of copyright files in binary packages according to https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/.

Questions to be discussed in this PR in particular:
* Is the `copyright` attribute really required? If vendor packages would include the third-party source code directly, the copyright attribute would not be required.
* Should this extension go into the existing version 3 (and thus REP-0149) or should the version number be increased?