### PR TITLE
REP-2001: Remove confusing comment

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -35,7 +35,7 @@ End-user entry points
 
 We define various entry points for ROS users.
 
- * `desktop_full` (available from Humble): The `desktop_full` variant provides a "batteries included" experience, enabling novice users to complete most entry tutorials without knowledge of the underlying library structure.
+ * `desktop_full`: The `desktop_full` variant provides a "batteries included" experience, enabling novice users to complete most entry tutorials without knowledge of the underlying library structure.
  * `desktop` (recommended): The `desktop` variant provides all commonly used libraries as well as
    visualization tools and tutorials.
  * `ros_base`: The `ros_base` variant composes the `ros_core` metapackage with commonly used libraries.


### PR DESCRIPTION
On #334 I changed "recommended from Humble" to "available from Humble" according to reviewer feedback, but that ended up making things confusing. Aren't `simulation` and `perception` also only available from Humble? (i.e. https://github.com/osrf/docker_images/pull/619#issuecomment-1124132514).

I think it's clearer if the entry-point list doesn't say anything about versions, and instead users can check each version below as needed.