### PR TITLE
Debian Buster EOL 2022 Sep

### DIFF
--- a/rep-0003.rst
+++ b/rep-0003.rst
@@ -383,14 +383,12 @@ Binary packages are built until the platform reaches its EOL date.
 +----------+---------------+----------------+-----------+
 | Arch     | Ubuntu Focal  | Debian Buster  | Fedora 32 |
 +==========+===============+================+===========+
-| amd64    | Until Apr '25 | Until ??? '22  |           |
+| amd64    | Until Apr '25 | Until Sep '22  |           |
 +----------+---------------+----------------+-----------+
-| arm64    | Until Apr '25 | Until ??? '22  |           |
+| arm64    | Until Apr '25 | Until Sep '22  |           |
 +----------+---------------+----------------+-----------+
 | arm32    | Until Apr '25 |                |           |
 +----------+---------------+----------------+-----------+
-
-???: Buster's EOL date has not been decided yet https://wiki.debian.org/DebianReleases
 
 Targeted Languages:
 


### PR DESCRIPTION
Debian Buster is EOL

https://www.debian.org/News/2022/20220910