### PR TITLE
Fix broken references to plaintext reps, and broken link in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,18 +1,15 @@
 reStructuredText for REPs
 =========================
 
-This is a direct search-and-replace port of the Python REP
+This is a direct search-and-replace port of the Python PEP
 scripts at:
 
-http://svn.python.org/projects/reps/trunk/
+http://svn.python.org/projects/peps/trunk/
 
 Original (modified) README.txt follows:
 
-Original REP source may be written using two standard formats, a
-mildly idiomatic plaintext format and the reStructuredText format
-(also, technically plaintext).  These two formats are described in REP
-9 and REP 12 respectively.  The rep2html.py processing and
-installation script knows how to produce the HTML for either REP
-format.  A local copy of the Docutils package is included for
-processing reStructuredText REPs.
-
+Original REP source is written using the reStructuredText
+format. This format is described in REP 12. The rep2html.py
+processing and installation script knows how to produce the
+HTML for the REP format. A local copy of the Docutils
+package is included for processing reStructuredText REPs.

--- a/rep-0012.rst
+++ b/rep-0012.rst
@@ -640,7 +640,7 @@ list`_.  The `Docutils project web site`_ has more information.
 References
 ==========
 
-.. [1] REP 1, REP Purpose and Guidelines, Warsaw, Hylton
+.. [1] REP 1, REP Purpose and Guidelines, Conley
    (https://ros.org/reps/rep-0001.html)
 
 

--- a/rep-0012.rst
+++ b/rep-0012.rst
@@ -24,9 +24,6 @@ To get the source this (or any) REP, look at the top of the HTML page
 and click on the date & time on the "Last-Modified" line.  It is a
 link to the source text in the ROS repository.
 
-If you would prefer not to use markup in your REP, please see REP 9,
-"Sample Plaintext REP Template" [2]_.
-
 This template is entirely based on the PEP 9 template by David Goodger
 and Barry Warsaw.  The Author field of this document has been changed
 in order to reflect reponsibility for maintenance.
@@ -39,7 +36,7 @@ to the format guidelines set forth below.  Use this template, in
 conjunction with the format guidelines below, to ensure that your
 REP submission won't get automatically rejected because of form.
 
-ReStructuredText is offered as an alternative to plaintext REPs, to
+ReStructuredText is used to
 allow REP authors more functionality and expressivity, while
 maintaining easy readability in the source text.  The processed HTML
 form makes the functionality accessible to readers: live hyperlinks,
@@ -108,8 +105,8 @@ directions below.
 - For Standards Track REPs, after the Created header, add a
   ROS-Version header and set the value to the next planned version
   of ROS, i.e. the one your new feature will hopefully make its
-  first appearance in.  Do not use an unstable release here (e.g. 1.3.x). 
-  Thus, if the last version of ROS was 1.2.2 and you're hoping to get 
+  first appearance in.  Do not use an unstable release here (e.g. 1.3.x).
+  Thus, if the last version of ROS was 1.2.2 and you're hoping to get
   your new feature into ROS 1.4, set the header to::
 
       ROS-Version: 1.4
@@ -271,7 +268,7 @@ per indent level.
 Literal Blocks
 --------------
 
-..  
+..
     In the text below, double backquotes are used to denote inline
     literals.  "``::``" is written so that the colons will appear in a
     monospaced font; the backquotes (``) are markup, not part of the
@@ -538,13 +535,13 @@ Graphs
 ROS REPs support `mermaid diagrams`_
 
 
-.. _mermaid diagrams: https://knsv.github.io/mermaid/ 
+.. _mermaid diagrams: https://knsv.github.io/mermaid/
 
-You can create flow charts: 
-  
-  
+You can create flow charts:
+
+
 .. raw:: html
-  
+
   <div class="mermaid">
   %% Example diagram
   graph LR
@@ -645,9 +642,6 @@ References
 
 .. [1] REP 1, REP Purpose and Guidelines, Warsaw, Hylton
    (https://ros.org/reps/rep-0001.html)
-
-.. [2] REP 9, Sample Plaintext REP Template, Warsaw
-   (https://ros.org/reps/pep-0009.html)
 
 
 Copyright

--- a/rep-0128.rst
+++ b/rep-0128.rst
@@ -287,7 +287,7 @@ With this layout, sourcing ~/rosbuild_ws/setup.*sh also sources ~/catkin_ws/deve
 References
 ==========
 
-.. [1] REP 1, REP Purpose and Guidelines, Warsaw, Hylton
+.. [1] REP 1, REP Purpose and Guidelines, Conley
    (https://ros.org/reps/rep-0001.html)
 
 


### PR DESCRIPTION
There is no example plaintext REP, every REP is in RST. Remove that language from README (fixing broken PEP link), and remove from REP 12, which points to REP 9 as an example of plaintext, but which REP 9 actually contains ABI Compatibility information.