### PR TITLE
Small cleanups to the REP scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ xsdvalid:
 	$(PYTHON) xsdValid.py
 
 clean:
-	-rm *.html
-	-rm rep-0000.rst
+	-rm -f *.html
+	-rm -f rep-0000.rst
 
 upload: all
 	rsync -r README.txt *.html mermaid.js css rep-0000.rst $(SUBDIRS) rosbot@ros.osuosl.org:/var/www/www.ros.org/reps

--- a/genrepindex.py
+++ b/genrepindex.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2.5
 """Auto-generate REP 0 (REP index).
 
 Generating the REP index is a multi-step process.  To begin, you must first

--- a/rep2html.py
+++ b/rep2html.py
@@ -70,9 +70,9 @@ DTD = ('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"\n'
        '                      "http://www.w3.org/TR/REC-html40/loose.dtd">')
 
 fixpat = re.compile(
-    "((https?|ftp):[-_a-zA-Z0-9/.+~:?#$=&,]+)|(rep-\d+(.rst)?)|"
-    "(RFC[- ]?(?P<rfcnum>\d+))|"
-    "(REP\s+(?P<repnum>\d+))|"
+    r"((https?|ftp):[-_a-zA-Z0-9/.+~:?#$=&,]+)|(rep-\d+(.rst)?)|"
+    r"(RFC[- ]?(?P<rfcnum>\d+))|"
+    r"(REP\s+(?P<repnum>\d+))|"
     ".")
 
 EMPTYSTRING = ''
@@ -220,7 +220,7 @@ def fixfile(inpath, input_lines, outfile):
     for k, v in header:
         if k.lower() in ('author', 'discussions-to'):
             mailtos = []
-            for part in re.split(',\s*', v):
+            for part in re.split(r',\s*', v):
                 if '@' in part:
                     realname, addr = parseaddr(part)
                     if k.lower() == 'discussions-to':
@@ -236,7 +236,7 @@ def fixfile(inpath, input_lines, outfile):
             v = COMMASPACE.join(mailtos)
         elif k.lower() in ('replaces', 'replaced-by', 'requires'):
             otherreps = ''
-            for otherrep in re.split(',?\s+', v):
+            for otherrep in re.split(r',?\s+', v):
                 otherrep = int(otherrep)
                 otherreps += '<a href="rep-%04d.html">%i</a> ' % (otherrep,
                                                                   otherrep)

--- a/xsdValid.py
+++ b/xsdValid.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import xmlschema
 
 format1 = xmlschema.XMLSchema('xsd/package_format1.xsd')


### PR DESCRIPTION
1.  Removes instances of /usr/bin/env python, which don't work on non-Linux and also were wrong in some cases.
2.  Makes sure to use raw strings for regexes, which gets rid of some warnings with modern Python.
3.  Uses '-f' when removing files to quite warnings.