### PR TITLE
[REP-2001] Add colcon mixin to ros-dev-tools

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -904,7 +904,8 @@ Dev Tools
   - ros-dev-tools:
       extends:  [ros-build-essential]
       packages: [python3-bloom, python3-colcon-common-extensions,
-                 python3-rosdep, python3-vcstool, wget]
+                 python3-colcon-mixin, python3-rosdep,
+                 python3-vcstool, wget]
 
 
 


### PR DESCRIPTION
As a developer I often rely on [colcon mixin](https://github.com/colcon/colcon-mixin-repository) to pass build flags for my projects. For convenience, I'd like to propose adding this package to the `ros-dev-tools` variant. If approved, I can follow up with changes needed to [infra-variants](https://github.com/ros-infrastructure/infra-variants).