### PR TITLE
Relax the XSD for package format 1, 2, and 3.

### DIFF
--- a/xsd/package_format1.xsd
+++ b/xsd/package_format1.xsd
@@ -30,17 +30,26 @@
         <xs:element name="name" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>
+              The package name must start with a letter and contain only
+              lowercase alphabetic, numeric, or underscore characters.
               The package name should be unique within the ROS community.
               It may differ from the folder name into which it is checked out,
               but that is not recommended.
-              It must start with a lower-case letter and consist of only
-              lower-case letters, numbers and underscores.
-              It must not have two consecutive underscores.
+
+              The following recommended exemptions apply, which are optional
+              for implementations:
+              - Dashes may be permitted in package names. This is to support
+                maintaining a consistent dependency name when transitioning back
+                and forth between a system dependency and in-workspace package,
+                since many rosdep keys contain dashes (inherited from the
+                Debian/Ubuntu name).
+              - In support of some legacy packages, capital letters may also be
+                accepted in the package name, with a validation warning.
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:token">
-              <xs:pattern value="[a-z](_?[a-z0-9]+)*"/>
+              <xs:pattern value="[A-Za-z]([_-]?[0-9A-Za-z]+)*"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:element>

--- a/xsd/package_format2.xsd
+++ b/xsd/package_format2.xsd
@@ -30,17 +30,26 @@
         <xs:element name="name" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>
+              The package name must start with a letter and contain only
+              lowercase alphabetic, numeric, or underscore characters.
               The package name should be unique within the ROS community.
               It may differ from the folder name into which it is checked out,
               but that is not recommended.
-              It must start with a lower-case letter and consist of only
-              lower-case letters, numbers and underscores.
-              It must not have two consecutive underscores.
+
+              The following recommended exemptions apply, which are optional
+              for implementations:
+              - Dashes may be permitted in package names. This is to support
+                maintaining a consistent dependency name when transitioning back
+                and forth between a system dependency and in-workspace package,
+                since many rosdep keys contain dashes (inherited from the
+                Debian/Ubuntu name).
+              - In support of some legacy packages, capital letters may also be
+                accepted in the package name, with a validation warning.
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:token">
-              <xs:pattern value="[a-z](_?[a-z0-9]+)*"/>
+              <xs:pattern value="[A-Za-z]([_-]?[0-9A-Za-z]+)*"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:element>

--- a/xsd/package_format3.xsd
+++ b/xsd/package_format3.xsd
@@ -67,17 +67,26 @@
         <xs:element name="name" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>
+              The package name must start with a letter and contain only
+              lowercase alphabetic, numeric, or underscore characters.
               The package name should be unique within the ROS community.
               It may differ from the folder name into which it is checked out,
               but that is not recommended.
-              It must start with a lower-case letter and consist of only
-              lower-case letters, numbers and underscores.
-              It must not have two consecutive underscores.
+
+              The following recommended exemptions apply, which are optional
+              for implementations:
+              - Dashes may be permitted in package names. This is to support
+                maintaining a consistent dependency name when transitioning back
+                and forth between a system dependency and in-workspace package,
+                since many rosdep keys contain dashes (inherited from the
+                Debian/Ubuntu name).
+              - In support of some legacy packages, capital letters may also be
+                accepted in the package name, with a validation warning.
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:token">
-              <xs:pattern value="[a-z](_?[a-z0-9]+)*"/>
+              <xs:pattern value="[a-zA-Z]([_-]?[0-9a-zA-Z]+)*"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:element>


### PR DESCRIPTION
Each of them has the same note in their corresponding REPs (https://www.ros.org/reps/rep-0127.html#name,
https://www.ros.org/reps/rep-0140.html#name,
https://www.ros.org/reps/rep-0149.html#name):

"
The package name must start with a letter and contain only lowercase alphabetic, numeric or underscore characters. The package name should be unique within the ROS community. It may differ from the folder name into which it is checked out, but that is not recommended.

The following recommended exemptions apply, which are optional for implementations:

- Dashes may be permitted in package names. This is to support maintaining a consistent dependency name when transitioning back and forth between a system dependency and in-workspace package, since many rosdep keys contain dashes (inherited from the Debian/Ubuntu name).
- In support of some legacy packages, capital letters may also be accepted in the package name, with a validation warning. "

The XSD should reflect this entire section, including the optional bits about allowing dashes and allowing capital letters.  If we want to disallow them in some circumstances, then the downstream linters should enforce that.

Because of that, this PR relaxes the XSD for each of the package formats to accept the full range.

Note to reviewers: please carefully check the regular expression.  In my local testing this seems to do the correct thing, but we want to make really sure that this is correct before we merge and deploy this.