### PR TITLE
Update the Python minimum to 3.8 for Iron and Jazzy.

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -1001,7 +1001,7 @@ For example a Tier 1 middleware implementation on a Tier 2 platform can only rec
 Minimum language requirements:
 
 - C++17
-- Python 3.10
+- Python 3.8
 
 
 Dependency Requirements:
@@ -1117,7 +1117,7 @@ For example a Tier 1 middleware implementation on a Tier 2 platform can only rec
 Minimum language requirements:
 
 - C++17
-- Python 3.9
+- Python 3.8
 
 
 Dependency Requirements:


### PR DESCRIPTION
Because of various issues, we are stuck on Python 3.8 for both Iron and Jazzy.  Update REP-2000 to reflect this fact.

See https://github.com/ros-infrastructure/ros2-cookbooks/pull/69 for more of the motivation behind this PR.

@Yadunund FYI