### PR TITLE
Update reference to Rolling target platforms

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -1191,7 +1191,7 @@ Rolling Ridley (June 2020 - Ongoing)
 Rolling Ridley is a rolling development distribution of ROS 2 as described in REP-2002 [8]_.
 
 The target platform for Rolling Ridley will update as new upstream distributions are selected for ROS 2 development.
-As of March 2022, Rolling Ridley targets the same platforms as ROS 2 Humble Hawksbill.
+As of May 2024, Rolling Ridley targets the same platforms as ROS 2 Jazzy Jalisco.
 
 
 Motivation


### PR DESCRIPTION
Alternatively, we could remove this line or replace it with something like:

> Rolling Ridley targets the same platforms as the latest (non-Rolling) distribution above.