### PR TITLE
Remove action_tutorials_interfaces from the Rolling desktop package.

### DIFF
--- a/rep-2001.rst
+++ b/rep-2001.rst
@@ -925,12 +925,11 @@ Desktop
 
   - desktop:
       extends:  [ros_base]
-      packages: [action_tutorials_cpp, action_tutorials_interfaces,
-                 action_tutorials_py, angles, composition,
-                 demo_nodes_cpp, demo_nodes_cpp_native,
-                 demo_nodes_py, depthimage_to_laserscan,
-                 dummy_map_server, dummy_robot_bringup,
-                 dummy_sensors,
+      packages: [action_tutorials_cpp, action_tutorials_py,
+                 angles, composition, demo_nodes_cpp,
+                 demo_nodes_cpp_native, demo_nodes_py,
+                 depthimage_to_laserscan, dummy_map_server,
+                 dummy_robot_bringup, dummy_sensors,
                  examples_rclcpp_minimal_action_client,
                  examples_rclcpp_minimal_action_server,
                  examples_rclcpp_minimal_client,


### PR DESCRIPTION
It was removed in https://github.com/ros2/demos/pull/701 (since it was a duplicate with some other packages), and then further removed from the variants in https://github.com/ros2/variants/pull/44, so that should be reflected here as well.

@ahcorde FYI