### PR TITLE
Changes on REP 2005 due to package name change of Fast DDS

### DIFF
--- a/rep-2005.rst
+++ b/rep-2005.rst
@@ -267,11 +267,10 @@ All items on the list for the next distro should already be released into the ro
   * FastRTPS
 
     * `fastcdr/fastcdr <https://index.ros.org/p/fastcdr/>`_
-    * `fastrtps/fastrtps <https://index.ros.org/p/fastrtps/>`_
+    * `fastdds/fastdds <https://index.ros.org/p/fastdds/>`_
     * `rmw_fastrtps/rmw_fastrtps_cpp <https://index.ros.org/p/rmw_fastrtps_cpp/>`_
     * `rmw_fastrtps/rmw_fastrtps_dynamic_cpp <https://index.ros.org/p/rmw_fastrtps_dynamic_cpp/>`_
     * `rmw_fastrtps/rmw_fastrtps_shared_cpp <https://index.ros.org/p/rmw_fastrtps_shared_cpp/>`_
-    * `rosidl_typesupport_fastrtps/fastrtps_cmake_module <https://index.ros.org/p/fastrtps_cmake_module/>`_
     * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_c <https://index.ros.org/p/rosidl_typesupport_fastrtps_c/>`_
     * `rosidl_typesupport_fastrtps/rosidl_typesupport_fastrtps_cpp <https://index.ros.org/p/rosidl_typesupport_fastrtps_cpp/>`_
 


### PR DESCRIPTION
As [discussed](https://docs.google.com/document/d/1TGXYp33N00ZJtilsRzfClFXcSyMa4QKVNmA03Lx9D7w/edit?disco=AAABfJswkzE) on the ROS PMC meeting of March 4th, 2025 we need to update REP 2005 with the changes done on the distributed packages after the name change of Fast DDS from `fastrtps` to `fastdds`.