### PR TITLE
Fix the CI runner to use Ubuntu 24.04.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: |
-          python -m pip install docutils xmlschema pygments
+          python -m pip install docutils pygments xmlschema
       - name: Run tests
         run: |
           make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
     build:
       name: run rep tests
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-24.04
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{matrix.python}}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies
         run: |
           python -m pip install docutils xmlschema

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: |
-          python -m pip install docutils xmlschema
+          python -m pip install docutils xmlschema pygments
       - name: Run tests
         run: |
           make


### PR DESCRIPTION
While we are in here, also update the actions we depend on to their latest versions, and add in pygments to avoid a warning when running the tests.